### PR TITLE
fix(agents): Correct invalid 'Azure Principal Architect' references

### DIFF
--- a/.github/agents/adr.agent.md
+++ b/.github/agents/adr.agent.md
@@ -65,7 +65,7 @@ All ADRs must consider CAF best practices:
 
 When creating ADRs that impact architecture:
 
-- Reference WAF pillar assessments from Azure Principal Architect
+- Reference WAF pillar assessments from the `architect` agent
 - Document trade-offs between WAF pillars (Security, Reliability, Performance, Cost, Operations)
 - Include WAF-specific consequences in the Consequences section
 - Note which WAF pillar is being optimized and what is being sacrificed

--- a/.github/agents/diagram.agent.md
+++ b/.github/agents/diagram.agent.md
@@ -38,7 +38,7 @@ handoffs:
     prompt: Create an ADR documenting this architecture. Include the generated diagram as visual reference for the architectural decision.
     send: true
   - label: Return to Architect Review
-    agent: Azure Principal Architect
+    agent: architect
     prompt: Review the architecture diagram and provide additional WAF assessment feedback or refinements.
     send: true
 ---


### PR DESCRIPTION
## Summary

Fixes invalid agent references where 'Azure Principal Architect' was used instead of the correct agent name 'architect'.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `diagram.agent.md` | Handoff referenced non-existent agent | Changed to `architect` |
| `adr.agent.md` | WAF integration referenced non-existent agent | Changed to `architect` |

## Context

The 'Azure Principal Architect' agent does not exist. The available agents are:
- `adr`, `architect`, `bicep-code`, `bicep-plan`, `deploy`, `diagnose`, `diagram`, `docs`, `requirements`

## Validation

- [x] Markdown lint passed
- [x] Agent names now match existing files