### PR TITLE
docs: Update changelog and version for v7.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to **Agentic InfraOps** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.0] - 2026-02-02
+
+### Added
+
+- **Agent-to-Skill Migration Plan** - Comprehensive plan to reduce agents from 9 to 6
+  - Convert `diagram`, `adr`, `docs` agents to skills
+  - Create new `azure-adr` and `azure-workload-docs` skills
+  - Enhance `azure-diagrams` skill with agent patterns
+  - Enhance `make-skill-template` as interactive skill-creator
+  - Plan saved to `plan-agentToSkillMigration.prompt.md`
+
+### Changed
+
+- **README.md** - Complete format overhaul to match SMB-LZ polished style
+  - Added centered robot logo from Fluent UI emoji
+  - Added project shields with reference-style markdown links
+  - Added table of contents in collapsible details block
+  - Added emoji section headers and back-to-top navigation
+  - Added Built With tech stack badges
+
+### Fixed
+
+- **Skills Lint Fixes** - Resolved 7 markdown lint errors in skill files
+  - `.github/skills/azure-deployment-preflight/SKILL.md`
+  - `.github/skills/make-skill-template/SKILL.md`
+  - `.github/skills/azure-deployment-preflight/references/ERROR-HANDLING.md`
+
 ## [7.4.0] - 2026-01-23
 
 - feat(workflow): Implement automated versioning and branch protection (#40)

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,10 +1,10 @@
 # Version Information
 
-**Current Version:** 7.4.0
+**Current Version:** 7.5.0
 
-**Last Updated:** 2026-01-23
+**Last Updated:** 2026-02-02
 
-**Build:** e5e6ceb
+**Build:** pending
 
 ## Version History
 


### PR DESCRIPTION
## Summary

Updates CHANGELOG.md and VERSION.md for v7.5.0 release documenting today's planning session.

## Changes

### CHANGELOG.md
- **Added**: Agent-to-skill migration plan summary (reducing agents 9→6)
- **Changed**: README format overhaul to match SMB-LZ style
- **Fixed**: Skills markdown lint errors

### VERSION.md
- Updated version from 7.4.0 → 7.5.0
- Updated date to 2026-02-02

## Context

Today's session focused on planning the agent-to-skill migration:
- Analyzed all 9 agents for consolidation opportunities
- Reviewed Anthropic's skill best practices guide
- Created comprehensive migration plan
- Decided to convert `diagram`, `adr`, `docs` agents to skills
- Plan saved to `plan-agentToSkillMigration.prompt.md` (local)

Execution will continue tomorrow on feature branch `feature/agent-to-skill-migration`.

## Validation

- ✅ markdownlint passed
- ✅ commitlint passed