### PR TITLE
fix(devcontainer): Run markdownlint version check from /tmp to avoid config interference

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -153,7 +153,8 @@ printf "  %-15s %s\n" "Node.js:" "$(node --version 2>/dev/null || echo '❌ not 
 printf "  %-15s %s\n" "GitHub CLI:" "$(gh --version 2>/dev/null | head -n1 || echo '❌ not installed')"
 printf "  %-15s %s\n" "uv:" "$(uv --version 2>/dev/null || echo '❌ not installed')"
 printf "  %-15s %s\n" "Checkov:" "$(checkov --version 2>/dev/null || echo '❌ not installed')"
-printf "  %-15s %s\n" "markdownlint:" "$(markdownlint-cli2 --version 2>/dev/null || echo '❌ not installed')"
+# Run from /tmp to avoid .markdownlint-cli2.jsonc globs triggering a full lint
+printf "  %-15s %s\n" "markdownlint:" "$(cd /tmp && markdownlint-cli2 --version 2>/dev/null | head -n1 || echo '❌ not installed')"
 
 echo ""
 echo "🎉 Post-create setup completed!"

--- a/.devcontainer/update-tools.sh
+++ b/.devcontainer/update-tools.sh
@@ -58,5 +58,6 @@ echo "📊 Current tool versions:"
 printf "   %-15s %s\n" "Azure CLI:" "$(az version --query '\"azure-cli\"' -o tsv 2>/dev/null || echo 'unknown')"
 printf "   %-15s %s\n" "Bicep:" "$(az bicep version 2>/dev/null || echo 'unknown')"
 printf "   %-15s %s\n" "Checkov:" "$(checkov --version 2>/dev/null || echo 'unknown')"
-printf "   %-15s %s\n" "markdownlint:" "$(markdownlint-cli2 --version 2>/dev/null || echo 'unknown')"
+# Run from /tmp to avoid .markdownlint-cli2.jsonc globs triggering a full lint
+printf "   %-15s %s\n" "markdownlint:" "$(cd /tmp && markdownlint-cli2 --version 2>/dev/null | head -n1 || echo 'unknown')"
 echo ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-agentic-infraops",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-agentic-infraops",
-      "version": "7.4.0",
+      "version": "7.5.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",


### PR DESCRIPTION
## Summary
The `.markdownlint-cli2.jsonc` config has `"globs": ["**/*.md"]` which causes `markdownlint-cli2 --version` to trigger a full lint run instead of just printing the version.

This caused the post-create script to show:
```
Finding: --version **/*.md ...
Linting: 155 file(s)
Summary: 2 error(s)
❌ not installed
```

## Fix
Run the version check from `/tmp` to avoid loading the workspace config file.

## Files Changed
- `.devcontainer/post-create.sh`
- `.devcontainer/update-tools.sh`