### PR TITLE
feat(skills): Add github-pull-requests skill for PR lifecycle management

### DIFF
--- a/.github/skills/github-pull-requests/SKILL.md
+++ b/.github/skills/github-pull-requests/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: github-pull-requests
+description: >
+  Manage GitHub pull requests using MCP tools. Use this skill when users want to
+  create PRs, review code, merge branches, request reviews, update PR details,
+  or check PR status. Triggers on requests like "create a PR", "merge this branch",
+  "request a review", "update the PR description", "check PR status", or any
+  pull request lifecycle task.
+---
+
+# GitHub Pull Requests
+
+Manage GitHub pull requests using the GitHub MCP server tools.
+
+## Available MCP Tools
+
+| Tool                                 | Purpose                              |
+| ------------------------------------ | ------------------------------------ |
+| `mcp_github_create_pull_request`     | Create new pull requests             |
+| `mcp_github_merge_pull_request`      | Merge pull requests                  |
+| `mcp_github_update_pull_request`     | Update PR title, body, reviewers     |
+| `mcp_github_update_pull_request_branch` | Sync PR branch with base          |
+| `mcp_github_pull_request_review_write` | Create/submit/delete reviews       |
+| `mcp_github_request_copilot_review`  | Request GitHub Copilot code review   |
+| `mcp_github_search_pull_requests`    | Search PRs with GitHub search syntax |
+| `mcp_github_list_pull_requests`      | List PRs in a repository             |
+
+## Workflow
+
+1. **Determine action**: Create, merge, review, or query?
+2. **Gather context**: Get repo info, branch names, existing PRs
+3. **Structure content**: Use templates from [references/templates.md](references/templates.md)
+4. **Execute**: Call the appropriate MCP tool
+5. **Confirm**: Report the PR URL and status to user
+
+## Creating Pull Requests
+
+### Required Parameters
+
+```yaml
+owner: repository owner (org or user)
+repo: repository name
+title: clear, descriptive title
+head: branch containing changes (source)
+base: branch to merge into (target, usually 'main')
+```
+
+### Optional Parameters
+
+```yaml
+body: PR description (markdown)
+draft: true/false (create as draft)
+maintainer_can_modify: true/false
+```
+
+### Title Guidelines
+
+- Use conventional commit style when appropriate: `feat:`, `fix:`, `docs:`
+- Be specific about the change
+- Keep under 72 characters
+- Examples:
+  - `feat: Add dark mode support`
+  - `fix(auth): Resolve SSO login failure`
+  - `docs: Update API reference for v2`
+
+### Body Structure
+
+Use the PR template from [references/templates.md](references/templates.md). Key sections:
+
+- **Summary**: What changed and why
+- **Changes**: Bullet list of modifications
+- **Testing**: How to verify the changes
+- **Checklist**: Pre-merge verification items
+
+## Merging Pull Requests
+
+### Required Parameters
+
+```yaml
+owner: repository owner
+repo: repository name
+pullNumber: PR number (integer)
+```
+
+### Optional Parameters
+
+```yaml
+merge_method: "squash" | "merge" | "rebase"
+commit_title: custom merge commit title
+commit_message: custom merge commit message
+```
+
+### Merge Methods
+
+| Method   | Use Case                                      |
+| -------- | --------------------------------------------- |
+| `squash` | Clean history, combine all commits into one   |
+| `merge`  | Preserve full commit history                  |
+| `rebase` | Linear history without merge commits          |
+
+**Default**: Use `squash` unless the user specifies otherwise.
+
+## Reviewing Pull Requests
+
+### Creating a Review
+
+Use `mcp_github_pull_request_review_write` with `method: "create"`:
+
+```yaml
+owner: repository owner
+repo: repository name
+pullNumber: PR number
+event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT"
+body: review comment text
+```
+
+### Review Events
+
+| Event             | Use When                                    |
+| ----------------- | ------------------------------------------- |
+| `APPROVE`         | Changes look good, ready to merge           |
+| `REQUEST_CHANGES` | Issues must be addressed before merge       |
+| `COMMENT`         | Feedback without explicit approval/blocking |
+
+### Request Copilot Review
+
+For automated code review feedback:
+
+```yaml
+owner: repository owner
+repo: repository name
+pullNumber: PR number
+```
+
+## Updating Pull Requests
+
+Use `mcp_github_update_pull_request` to modify:
+
+```yaml
+owner: repository owner
+repo: repository name
+pullNumber: PR number (required)
+# Optional - only include fields to change:
+title: new title
+body: new description
+state: "open" | "closed"
+base: new base branch
+draft: true/false (mark as draft or ready)
+reviewers: ["username1", "username2"]
+```
+
+## Searching Pull Requests
+
+Use `mcp_github_search_pull_requests` with GitHub search syntax:
+
+### Common Search Queries
+
+| Goal                          | Query                                    |
+| ----------------------------- | ---------------------------------------- |
+| Open PRs in repo              | `repo:owner/repo is:open`                |
+| PRs by author                 | `author:username`                        |
+| PRs needing review            | `review:required`                        |
+| Draft PRs                     | `draft:true`                             |
+| PRs with label                | `label:bug`                              |
+| Recently updated              | `updated:>2024-01-01`                    |
+| PRs mentioning text           | `"search term" in:title,body`            |
+
+## Examples
+
+### Example 1: Create a PR
+
+**User**: "Create a PR from my feature branch to main"
+
+**Action**: Call `mcp_github_create_pull_request`:
+
+```json
+{
+  "owner": "jonathan-vella",
+  "repo": "azure-agentic-infraops",
+  "title": "feat: Add dark mode support",
+  "head": "feature/dark-mode",
+  "base": "main",
+  "body": "## Summary\nAdds dark mode theme support.\n\n## Changes\n..."
+}
+```
+
+### Example 2: Merge with Squash
+
+**User**: "Merge PR #70 using squash"
+
+**Action**: Call `mcp_github_merge_pull_request`:
+
+```json
+{
+  "owner": "jonathan-vella",
+  "repo": "azure-agentic-infraops",
+  "pullNumber": 70,
+  "merge_method": "squash",
+  "commit_title": "feat: Add dark mode support (#70)"
+}
+```
+
+### Example 3: Request Changes
+
+**User**: "Request changes on PR #42 - needs more tests"
+
+**Action**: Call `mcp_github_pull_request_review_write`:
+
+```json
+{
+  "owner": "jonathan-vella",
+  "repo": "azure-agentic-infraops",
+  "pullNumber": 42,
+  "method": "create",
+  "event": "REQUEST_CHANGES",
+  "body": "This PR needs additional test coverage before merging.\n\n..."
+}
+```
+
+### Example 4: Update PR to Ready
+
+**User**: "Mark PR #55 as ready for review and add reviewers"
+
+**Action**: Call `mcp_github_update_pull_request`:
+
+```json
+{
+  "owner": "jonathan-vella",
+  "repo": "azure-agentic-infraops",
+  "pullNumber": 55,
+  "draft": false,
+  "reviewers": ["teammate1", "teammate2"]
+}
+```
+
+## Branch Management
+
+### Create Branch First
+
+Before creating a PR, ensure the branch exists using `mcp_github_create_branch`:
+
+```yaml
+owner: repository owner
+repo: repository name
+branch: new branch name
+from_branch: source branch (optional, defaults to default branch)
+```
+
+### Update Branch with Base
+
+To sync a PR branch with the latest changes from base:
+
+```yaml
+owner: repository owner
+repo: repository name
+pullNumber: PR number
+```
+
+## Tips
+
+- Always check if a PR already exists for the branch before creating
+- Use `squash` merge for cleaner history on feature branches
+- Request Copilot review for quick automated feedback before human review
+- Include issue references in PR body: `Closes #123` or `Fixes #456`
+- For draft PRs, set `draft: true` to indicate work-in-progress
+- After merging, the source branch can be deleted via GitHub UI
+
+## Common Labels for PRs
+
+| Label            | Use For                              |
+| ---------------- | ------------------------------------ |
+| `ready-for-review` | PR is ready for code review        |
+| `work-in-progress` | Still being worked on              |
+| `needs-tests`    | Missing test coverage                |
+| `breaking-change`| Contains breaking API changes        |
+| `documentation`  | Documentation updates                |
+| `dependencies`   | Dependency updates                   |

--- a/.github/skills/github-pull-requests/references/templates.md
+++ b/.github/skills/github-pull-requests/references/templates.md
@@ -1,0 +1,225 @@
+# Pull Request Templates
+
+Templates for structuring PR descriptions.
+
+## Standard PR Template
+
+```markdown
+## Summary
+
+Brief description of what this PR does and why.
+
+## Changes
+
+- Change 1
+- Change 2
+- Change 3
+
+## Testing
+
+Describe how to test these changes:
+
+1. Step 1
+2. Step 2
+3. Expected result
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots for UI changes -->
+
+## Checklist
+
+- [ ] Tests pass locally
+- [ ] Code follows project style guidelines
+- [ ] Documentation updated (if needed)
+- [ ] No sensitive data exposed
+```
+
+## Feature PR Template
+
+```markdown
+## Summary
+
+Adds [feature name] to enable [capability].
+
+**Related Issue**: Closes #XXX
+
+## Changes
+
+### Added
+
+- New component/module for X
+- API endpoint for Y
+
+### Modified
+
+- Updated Z to support new feature
+
+## Testing
+
+### Manual Testing
+
+1. Navigate to [location]
+2. Perform [action]
+3. Verify [expected result]
+
+### Automated Tests
+
+- [ ] Unit tests added for new functions
+- [ ] Integration tests updated
+
+## Documentation
+
+- [ ] README updated
+- [ ] API docs updated
+- [ ] Inline code comments added
+
+## Checklist
+
+- [ ] Tests pass
+- [ ] No breaking changes (or documented)
+- [ ] Reviewed for security implications
+```
+
+## Bug Fix PR Template
+
+```markdown
+## Summary
+
+Fixes [brief description of bug].
+
+**Related Issue**: Fixes #XXX
+
+## Root Cause
+
+Explain what was causing the bug.
+
+## Solution
+
+Describe the fix and why this approach was chosen.
+
+## Changes
+
+- File1: Description of change
+- File2: Description of change
+
+## Testing
+
+### Reproduction Steps (Before Fix)
+
+1. Step to reproduce
+2. Observe bug
+
+### Verification (After Fix)
+
+1. Same steps
+2. Bug no longer occurs
+
+## Regression Risk
+
+- [ ] Low - isolated change
+- [ ] Medium - affects related functionality
+- [ ] High - core system change
+
+## Checklist
+
+- [ ] Bug can no longer be reproduced
+- [ ] No new bugs introduced
+- [ ] Tests added to prevent regression
+```
+
+## Documentation PR Template
+
+```markdown
+## Summary
+
+Updates documentation for [topic].
+
+## Changes
+
+- Added/updated section on X
+- Fixed outdated information about Y
+- Improved clarity of Z
+
+## Review Notes
+
+Please verify:
+
+- [ ] Technical accuracy
+- [ ] Grammar and spelling
+- [ ] Links work correctly
+- [ ] Code examples are valid
+
+## Checklist
+
+- [ ] Markdown renders correctly
+- [ ] No broken links
+- [ ] Follows documentation style guide
+```
+
+## Dependency Update Template
+
+```markdown
+## Summary
+
+Updates [package name] from vX.X.X to vY.Y.Y.
+
+## Motivation
+
+- Security vulnerability fix (CVE-XXXX)
+- Bug fix required for [reason]
+- New feature needed: [feature]
+
+## Changes
+
+- Updated package.json / requirements.txt
+- Updated lock file
+
+## Breaking Changes
+
+<!-- List any breaking changes or "None" -->
+
+## Testing
+
+- [ ] Build succeeds
+- [ ] All tests pass
+- [ ] Application starts correctly
+- [ ] Key functionality verified
+
+## Changelog
+
+Link to package changelog: [CHANGELOG](url)
+```
+
+## Merge Commit Message Templates
+
+### Squash Merge (Default)
+
+```
+<type>: <description> (#PR_NUMBER)
+
+<optional body with details>
+```
+
+Examples:
+
+```
+feat: Add user authentication (#123)
+fix: Resolve memory leak in worker pool (#456)
+docs: Update API reference for v2 endpoints (#789)
+```
+
+### Conventional Commit Types
+
+| Type       | Description                               |
+| ---------- | ----------------------------------------- |
+| `feat`     | New feature                               |
+| `fix`      | Bug fix                                   |
+| `docs`     | Documentation only                        |
+| `style`    | Formatting, no code change                |
+| `refactor` | Code change that neither fixes nor adds   |
+| `perf`     | Performance improvement                   |
+| `test`     | Adding or updating tests                  |
+| `chore`    | Maintenance tasks, dependencies           |
+| `ci`       | CI/CD changes                             |
+| `build`    | Build system changes                      |


### PR DESCRIPTION
## Summary

Adds a new skill for managing GitHub pull requests using MCP tools.

## Features

- **Full PR lifecycle**: Create, merge, update, review PRs
- **Review workflows**: Create reviews, request Copilot review, approve/request changes
- **Search & discovery**: Search PRs with GitHub search syntax
- **Templates**: PR body templates for features, bugs, docs, dependencies

## Files Added

```
.github/skills/github-pull-requests/
├── SKILL.md              # Main skill instructions
└── references/
    └── templates.md      # PR description templates
```

## MCP Tools Covered

| Tool | Purpose |
|------|---------|
| `mcp_github_create_pull_request` | Create new PRs |
| `mcp_github_merge_pull_request` | Merge PRs |
| `mcp_github_update_pull_request` | Update PR details |
| `mcp_github_pull_request_review_write` | Submit reviews |
| `mcp_github_request_copilot_review` | Request Copilot review |
| `mcp_github_search_pull_requests` | Search PRs |

## Testing

The skill was used successfully to create and merge PR #70 in this session.

## Checklist

- [x] Follows skill structure conventions
- [x] Includes comprehensive examples
- [x] Markdown lint passes
- [x] Templates provided for common scenarios