### PR TITLE
docs(skills): Add README index for available skills

### DIFF
--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -1,0 +1,25 @@
+# Skills
+
+This directory contains Agent Skills for GitHub Copilot.
+
+## Available Skills
+
+| Skill                      | Description                           |
+| -------------------------- | ------------------------------------- |
+| `azure-deployment-preflight` | Azure deployment validation         |
+| `azure-diagrams`           | Generate architecture diagrams        |
+| `gh-cli`                   | GitHub CLI usage                      |
+| `git-commit`               | Conventional commit messages          |
+| `github-issues`            | Manage GitHub issues via MCP          |
+| `github-pull-requests`     | Manage GitHub pull requests via MCP   |
+| `make-skill-template`      | Create new skills from template       |
+
+## Usage
+
+Skills are automatically activated when your prompt matches the skill's description.
+You can also explicitly reference a skill folder for Copilot to load.
+
+## Creating New Skills
+
+Use the `make-skill-template` skill or follow the structure in
+[agent-skills.instructions.md](../instructions/agent-skills.instructions.md).


### PR DESCRIPTION
## Summary

Adds a README index to the skills directory for discoverability.

## Changes

- Added `.github/skills/README.md` listing all 7 available skills
- Includes usage instructions and link to skill creation guide

## Testing

This PR validates the new `github-pull-requests` skill by using the MCP tools
documented in that skill to create and merge this very PR.

## Checklist

- [x] Markdown lint passes
- [x] Follows documentation conventions