### PR TITLE
fix(ci): use native boolean for workflow_dispatch default

### DIFF
--- a/.github/workflows/avm-version-check.yml
+++ b/.github/workflows/avm-version-check.yml
@@ -13,7 +13,7 @@ on:
       create_issue:
         description: "Create GitHub issue for outdated modules"
         required: false
-        default: "true"
+        default: true
         type: boolean
 
 permissions:


### PR DESCRIPTION
Minor fix to use native boolean type instead of string for `workflow_dispatch` input default.

**Change:**
```yaml
# Before
default: "true"

# After  
default: true
```

This is cleaner for `type: boolean` inputs.