### PR TITLE
docs: clarify Terraform support is planned

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -171,7 +171,7 @@ azure-agentic-infraops/
 
 | Category            | Tools                                           |
 | ------------------- | ----------------------------------------------- |
-| **IaC**             | Bicep (primary), Terraform (optional)           |
+| **IaC**             | Bicep (Terraform support planned)               |
 | **Automation**      | PowerShell 7+, Azure CLI 2.50+, Bicep CLI 0.20+ |
 | **Platform**        | Azure (public cloud)                            |
 | **AI**              | GitHub Copilot with custom agents               |


### PR DESCRIPTION
Updates `copilot-instructions.md` to clarify that Terraform support is planned (not yet available).

**Change:**
```diff
- | **IaC**             | Bicep (primary), Terraform (optional)           |
+ | **IaC**             | Bicep (Terraform support planned)               |
```

**Related:** #85 (Terraform support roadmap issue)