### PR TITLE
fix(docs): remove hardcoded version numbers from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 
 ## 🚀 About The Project
 
-> **Version 8.0.0** | [Version info](VERSION.md) | [Changelog](CHANGELOG.md)
+> [Version info](VERSION.md) | [Changelog](CHANGELOG.md)
 
 IT Pro–focused workflow for building and operating Azure environments with guardrailed AI agents.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Agentic InfraOps Documentation
 
-> Version 8.0.0 | Azure infrastructure engineered by AI agents and skills
+> Azure infrastructure engineered by AI agents and skills | [Current Version](../VERSION.md)
 
 Transform Azure infrastructure requirements into deploy-ready Bicep code using coordinated
 AI agents and reusable skills, aligned with Azure Well-Architected Framework (WAF) and


### PR DESCRIPTION
## Problem

Version numbers were hardcoded in multiple README files, requiring manual updates with each release.

## Solution

Remove hardcoded version numbers and link to `VERSION.md` instead.

**Before:**
```markdown
> **Version 8.0.0** | [Version info](VERSION.md) | [Changelog](CHANGELOG.md)
```

**After:**
```markdown
> [Version info](VERSION.md) | [Changelog](CHANGELOG.md)
```

## Benefits

- ✅ Single source of truth: `VERSION.md`
- ✅ No more forgotten version updates in docs
- ✅ `validate-version-sync.mjs` only checks 3 files (VERSION.md, package.json, CHANGELOG.md)