### PR TITLE
fix: Address Copilot review suggestions (model rules, lint triggers, paths)

### DIFF
--- a/.github/instructions/agents-definitions.instructions.md
+++ b/.github/instructions/agents-definitions.instructions.md
@@ -57,6 +57,24 @@ handoffs:
 - Use Title Case for the `agent` value matching the agent's display `name` (from frontmatter).
   For example: `agent: Architect` (matching `name: Architect` in frontmatter).
 
+### `model`
+
+> [!IMPORTANT]
+> **Model selection is intentional and must not be changed without explicit approval.**
+
+Agents that specify `Claude Opus 4.5` as priority model do so deliberately:
+
+- **Opus-first agents** (requirements, architect, bicep-plan) require advanced reasoning
+  for accurate planning decisions, WAF assessments, and governance discovery
+- **Sonnet-first agents** (bicep-code, deploy) prioritize speed for implementation tasks
+
+**Rules:**
+
+1. **Never reorder models** to put Sonnet before Opus if Opus is currently first
+2. **Planning accuracy trumps cost/speed** - incorrect plans waste more resources than Opus costs
+3. When adding `model` arrays, match the pattern of similar workflow-stage agents
+4. Document any model changes in PR description with justification
+
 ## Shared Defaults (Required)
 
 All top-level workflow agents in `.github/agents/` MUST include this near the top of the file:

--- a/.github/skills/azure-deployment-preflight/SKILL.md
+++ b/.github/skills/azure-deployment-preflight/SKILL.md
@@ -81,8 +81,10 @@ azd provision --preview --environment <env-name>
 
 #### For Standalone Bicep (no azure.yaml)
 
-> **CRITICAL**: Always use **default output format** (no `--output` flag) for what-if commands.
-> This enables VS Code's formatted rendering with tables, icons, and color-coded status.
+> [!IMPORTANT]
+> For detailed guidance on `what-if` output formatting, refer to the Deploy agent instructions
+> (single source of truth). Use default output format (no `--output` flag) to enable VS Code's
+> formatted rendering with tables, icons, and color-coded status.
 
 Determine the deployment scope from the Bicep file's `targetScope` declaration:
 

--- a/.github/templates/04-governance-constraints.template.md
+++ b/.github/templates/04-governance-constraints.template.md
@@ -186,4 +186,4 @@ tags: {
 ---
 
 *Governance constraints discovered from Azure Resource Graph.*
-*See [governance-discovery.instructions.md](../../.github/instructions/governance-discovery.instructions.md) for discovery methodology.*
+*See [governance-discovery.instructions.md](/.github/instructions/governance-discovery.instructions.md) for discovery methodology.*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main, "feature/*"]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Addresses Copilot code review suggestions (except model reordering which is intentionally rejected).

## Changes

### 1. Model Selection Rules (agents-definitions.instructions.md)

Added new `### model` section documenting that:
- **Opus-first agents must remain Opus** - planning accuracy trumps cost/speed
- Agents like `requirements`, `architect`, `bicep-plan` use Opus for advanced reasoning
- Model changes require explicit approval with justification

> [!NOTE]
> The suggestion to reorder models (Sonnet before Opus) was **intentionally rejected**.
> Planning agents require Opus's advanced reasoning for accurate WAF assessments and governance discovery.

### 2. Lint Workflow (lint.yml)

Removed `feature/*` from push triggers - only `main` branch pushes trigger the workflow.
Feature branches still trigger via `pull_request` event.

### 3. What-If Output Guidance (azure-deployment-preflight/SKILL.md)

Consolidated duplicated guidance by referencing Deploy agent as single source of truth.
Changed from inline CRITICAL note to reference pattern.

### 4. Template Path Fix (04-governance-constraints.template.md)

Changed relative path `../../.github/instructions/` to repo-root path `/.github/instructions/`
for more robust linking across different template locations.

## Validation

- [x] Markdown lint passes (0 errors)
- [x] All hooks pass (deprecated-refs, json-syntax, version-sync)