### PR TITLE
fix(vscode): Remove deprecated GitHub.copilot extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "GitHub.copilot",
     "GitHub.copilot-chat",
     "ms-azuretools.vscode-azure-github-copilot",
     "ms-azuretools.vscode-bicep",


### PR DESCRIPTION
## Description

Removes the deprecated `GitHub.copilot` extension from `.vscode/extensions.json` recommendations. This extension was merged into `GitHub.copilot-chat` and triggers a misleading "install recommended extension" prompt on every workspace open.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

**Files modified:**

- `.vscode/extensions.json` — removed `GitHub.copilot` from recommendations (kept `GitHub.copilot-chat`)

## Testing Performed

- [x] Pre-commit hooks passed
- [x] JSON syntax validated