### PR TITLE
fix(azure-pricing-mcp): align bulk estimate formatter with indices response shape

### DIFF
--- a/mcp/azure-pricing-mcp/src/azure_pricing_mcp/formatters.py
+++ b/mcp/azure-pricing-mcp/src/azure_pricing_mcp/formatters.py
@@ -492,7 +492,7 @@ def format_bulk_estimate_response(result: dict[str, Any]) -> str:
         lines.append("| # | Service | SKU | Region | Qty | Monthly | Yearly |")
         lines.append("|---|---------|-----|--------|-----|---------|--------|")
         for item in result["line_items"]:
-            item_nums = ", ".join(str(i + 1) for i in item.get("indices", []))
+            item_nums = ", ".join(str(i + 1) for i in item.get("indices", [])) or "N/A"
             lines.append(
                 f"| {item_nums} | {item['service_name']} | {item['sku_name']} "
                 f"| {item['region']} | {item['quantity']} "
@@ -506,7 +506,7 @@ def format_bulk_estimate_response(result: dict[str, Any]) -> str:
     if result["errors"]:
         lines.append("\n#### Errors")
         for err in result["errors"]:
-            err_nums = ", ".join(str(i + 1) for i in err.get("indices", []))
+            err_nums = ", ".join(str(i + 1) for i in err.get("indices", [])) or "N/A"
             lines.append(f"- Item(s) {err_nums}: {err['error']}")
 
     return "\n".join(lines)

--- a/mcp/azure-pricing-mcp/src/azure_pricing_mcp/formatters.py
+++ b/mcp/azure-pricing-mcp/src/azure_pricing_mcp/formatters.py
@@ -492,8 +492,9 @@ def format_bulk_estimate_response(result: dict[str, Any]) -> str:
         lines.append("| # | Service | SKU | Region | Qty | Monthly | Yearly |")
         lines.append("|---|---------|-----|--------|-----|---------|--------|")
         for item in result["line_items"]:
+            item_nums = ", ".join(str(i + 1) for i in item.get("indices", []))
             lines.append(
-                f"| {item['index']+1} | {item['service_name']} | {item['sku_name']} "
+                f"| {item_nums} | {item['service_name']} | {item['sku_name']} "
                 f"| {item['region']} | {item['quantity']} "
                 f"| ${item['monthly_cost']:,.2f} | ${item['yearly_cost']:,.2f} |"
             )
@@ -505,7 +506,8 @@ def format_bulk_estimate_response(result: dict[str, Any]) -> str:
     if result["errors"]:
         lines.append("\n#### Errors")
         for err in result["errors"]:
-            lines.append(f"- Item {err['index']+1}: {err['error']}")
+            err_nums = ", ".join(str(i + 1) for i in err.get("indices", []))
+            lines.append(f"- Item(s) {err_nums}: {err['error']}")
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary

Bug fix for `format_bulk_estimate_response()` in `formatters.py`.

## Problem

v4.1.0 bulk service changed the response shape from `index` (single int) to `indices` (list of ints) to support deduplication. The formatter was not updated to match, causing a `KeyError: 'index'` crash when formatting bulk estimate results.

## Fix

Updated both line_items (line ~496) and errors (line ~508) formatting:
- `item['index'] + 1` → `", ".join(str(i + 1) for i in item.get("indices", []))`
- Error label changed from `Item` to `Item(s)` to reflect potential multi-index references

## Testing

- 94/94 unit tests pass
- Live end-to-end integration test verified:
  - ✅ Bulk estimate with 5 resources (3 priced, 2 errors) — formatted correctly
  - ✅ Region recommend — 60 regions returned
  - ✅ Cache stats — working