### PR TITLE
feat: Add Microsoft Learn MCP, new skills, and language instructions

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -32,6 +32,7 @@ It includes all required tools, extensions, and configurations to build Azure in
 
 - **Azure MCP Server** - RBAC-aware Azure context for agents
 - **Azure Pricing MCP** - Real-time SKU pricing for cost estimates
+- **Microsoft Learn MCP** - Official Microsoft documentation search, code samples, and page fetching
 
 ### Python Libraries (Auto-installed)
 

--- a/.github/agents/03-architect.agent.md
+++ b/.github/agents/03-architect.agent.md
@@ -159,6 +159,8 @@ handoffs:
    - `.github/skills/azure-artifacts/templates/02-architecture-assessment.template.md`
    - `.github/skills/azure-artifacts/templates/03-des-cost-estimate.template.md`
      Use as structural skeletons (replicate badges, TOC, navigation, attribution exactly).
+4. **Read** `.github/skills/microsoft-docs/SKILL.md` — query official Microsoft docs for service limits,
+   SLAs, SKU comparisons, and WAF best practices
 
 These skills are your single source of truth. Do NOT use hardcoded values.
 

--- a/.github/agents/05-bicep-planner.agent.md
+++ b/.github/agents/05-bicep-planner.agent.md
@@ -153,6 +153,8 @@ handoffs:
    - `.github/skills/azure-artifacts/templates/04-implementation-plan.template.md`
    - `.github/skills/azure-artifacts/templates/04-governance-constraints.template.md`
      Use as structural skeletons (replicate badges, TOC, navigation, attribution exactly).
+4. **Read** `.github/skills/azure-bicep-patterns/SKILL.md` — reusable patterns for hub-spoke,
+   private endpoints, diagnostic settings, module composition
 
 These skills are your single source of truth. Do NOT use hardcoded values.
 

--- a/.github/agents/06-bicep-code-generator.agent.md
+++ b/.github/agents/06-bicep-code-generator.agent.md
@@ -153,6 +153,10 @@ handoffs:
    - `.github/skills/azure-artifacts/templates/04-preflight-check.template.md`
    - `.github/skills/azure-artifacts/templates/05-implementation-reference.template.md`
      Use as structural skeletons (replicate badges, TOC, navigation, attribution exactly).
+4. **Read** `.github/skills/microsoft-code-reference/SKILL.md` — verify AVM module parameters,
+   check API versions, find correct Bicep patterns via official docs
+5. **Read** `.github/skills/azure-bicep-patterns/SKILL.md` — hub-spoke, private endpoints,
+   diagnostic settings, managed identity, module composition patterns
 
 These skills are your single source of truth. Do NOT use hardcoded values.
 

--- a/.github/agents/09-diagnose.agent.md
+++ b/.github/agents/09-diagnose.agent.md
@@ -153,6 +153,10 @@ for troubleshooting existing deployments.
 **Before doing ANY work**, read:
 
 1. **Read** `.github/skills/azure-defaults/SKILL.md` — regions, tags, security baseline
+2. **Read** `.github/skills/microsoft-docs/SKILL.md` — look up official troubleshooting guides,
+   metric thresholds, KQL syntax, and diagnostic setting schemas
+3. **Read** `.github/skills/azure-troubleshooting/SKILL.md` — KQL templates, per-resource health checks,
+   severity classification, remediation playbooks
 
 ## Core Principles
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,13 +26,19 @@ All outputs → `agent-output/{project}/`. Context flows via artifact files + ha
 
 | Skill               | Purpose                                                   |
 | ------------------- | --------------------------------------------------------- |
-| `azure-defaults`    | Regions, tags, naming, AVM, security, governance, pricing |
-| `azure-artifacts`   | Template H2 structures, styling, generation rules         |
-| `azure-diagrams`    | Python architecture diagram generation                    |
-| `azure-adr`         | Architecture Decision Records                             |
-| `github-operations` | GitHub issues, PRs, CLI, Actions, releases                |
-| `git-commit`        | Commit message conventions                                |
-| `docs-writer`       | Documentation generation                                  |
+| `azure-defaults`           | Regions, tags, naming, AVM, security, governance, pricing       |
+| `azure-artifacts`          | Template H2 structures, styling, generation rules               |
+| `azure-bicep-patterns`     | Reusable Bicep patterns (hub-spoke, PE, diagnostics)            |
+| `azure-troubleshooting`    | KQL templates, health checks, remediation playbooks             |
+| `azure-diagrams`           | Python architecture diagram generation                          |
+| `azure-adr`                | Architecture Decision Records                                   |
+| `github-operations`        | GitHub issues, PRs, CLI, Actions, releases                      |
+| `git-commit`               | Commit message conventions                                      |
+| `docs-writer`              | Documentation generation                                        |
+| `make-skill-template`      | Scaffold new Agent Skills from templates                        |
+| `microsoft-docs`           | Query official Microsoft/Azure docs (requires Learn MCP)        |
+| `microsoft-code-reference` | Verify SDK methods and find working code samples (requires Learn MCP) |
+| `microsoft-skill-creator`  | Create hybrid skills for Microsoft technologies (requires Learn MCP) |
 
 Agents read skills via: **"Read `.github/skills/{name}/SKILL.md`"** in their body.
 

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -14,6 +14,10 @@ the language-specific instructions already in place:
   parameter validation, `$ErrorActionPreference = 'Stop'`)
 - **Shell**: `shell.instructions.md` (`set -euo pipefail`, `trap`,
   `jq`/`yq` for structured data)
+- **JavaScript**: `javascript.instructions.md` (ES modules, `node:`
+  protocol imports, validation script patterns)
+- **Python**: `python.instructions.md` (Ruff linting, `uv` packages,
+  diagrams library, async MCP patterns)
 - **Markdown**: `markdown.instructions.md` (120-char lines, ATX headings)
 
 When reviewing code, apply these general guidelines **in addition to**

--- a/.github/instructions/javascript.instructions.md
+++ b/.github/instructions/javascript.instructions.md
@@ -1,0 +1,92 @@
+---
+description: 'JavaScript and Node.js conventions for validation scripts and tooling'
+applyTo: '**/*.{js,mjs,cjs}'
+---
+
+# JavaScript Guidelines
+
+Instructions for writing clean, consistent JavaScript in this repository. All scripts
+target Node.js LTS (22+) and use ES modules (`.mjs`).
+
+## Module System
+
+- Use ES modules exclusively — all scripts use `.mjs` extension
+- Import Node.js built-ins with the `node:` protocol: `import fs from "node:fs"`
+- Prefer `node:fs/promises` over callback-based `node:fs` for async operations
+- Use named imports where practical: `import { readFile } from "node:fs/promises"`
+
+## Script Structure
+
+Follow the existing pattern in `scripts/`:
+
+```javascript
+#!/usr/bin/env node
+/**
+ * Brief description of what the script validates or does.
+ *
+ * @example
+ * node scripts/my-script.mjs
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+// Constants at top
+const SOME_DIR = ".github/agents";
+
+// Counters for validation scripts
+let errors = 0;
+let warnings = 0;
+
+// Functions...
+
+// Main execution at bottom with process.exit
+process.exit(errors > 0 ? 1 : 0);
+```
+
+## Conventions
+
+- Use `const` by default, `let` when reassignment is needed, never `var`
+- Use double quotes for strings (matches Prettier config)
+- Use template literals for string interpolation
+- Use `===` and `!==` for comparisons
+- Prefer arrow functions for callbacks
+- Use destructuring where it improves readability
+- End files with `process.exit(errors > 0 ? 1 : 0)` for validation scripts
+
+## Error Handling
+
+- Validation scripts: accumulate errors in a counter, log all issues, then exit
+  with non-zero code — do not throw on first error
+- Use `try/catch` for file operations that may fail
+- Log errors to stderr with descriptive messages including the file path
+- Use emoji prefixes for log output: `❌` errors, `⚠️` warnings, `✅` pass
+
+## File System Operations
+
+- Use `fs.readFileSync` for simple validation scripts (synchronous is fine)
+- Use `path.join()` or `path.resolve()` for paths — never string concatenation
+- Walk directories with `fs.readdirSync` and filter by extension
+- Check existence with `fs.existsSync` before reading
+
+## Frontmatter Parsing
+
+Many scripts parse YAML-like frontmatter from markdown:
+
+```javascript
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  // Parse key-value pairs...
+}
+```
+
+Keep frontmatter parsers simple — this project uses basic key-value YAML, not
+full YAML parsing. Do not add a YAML library dependency.
+
+## Dependencies
+
+- Minimize external dependencies — prefer Node.js built-ins
+- Current dev dependencies: `fast-xml-parser`, `markdownlint-cli2`, `lefthook`,
+  `commitlint`, `markdown-link-check`
+- Do not add runtime dependencies — this is a tooling-only `package.json`

--- a/.github/instructions/json.instructions.md
+++ b/.github/instructions/json.instructions.md
@@ -1,0 +1,44 @@
+---
+description: 'JSON and JSONC formatting conventions for configuration and data files'
+applyTo: '**/*.{json,jsonc}'
+---
+
+# JSON Guidelines
+
+Instructions for writing consistent JSON and JSONC files in this repository.
+
+## Formatting
+
+- **Formatter**: Prettier (configured in devcontainer)
+- **Indentation**: 2 spaces
+- **Trailing commas**: not allowed in `.json` files (invalid JSON)
+- **Line endings**: LF (`\n`) — enforced by `.editorconfig` / VS Code settings
+- **Final newline**: always include a trailing newline
+
+## JSONC (JSON with Comments)
+
+Files like `.vscode/mcp.json`, `devcontainer.json`, and `.markdownlint-cli2.jsonc`
+use JSONC format:
+
+- Use `//` for single-line comments explaining non-obvious configuration
+- Group related settings with section comments
+- Do not use `/* */` block comments
+
+## Key Ordering
+
+For configuration files, follow a logical grouping:
+
+- **`package.json`**: `name`, `version`, `description`, `private`, `scripts`,
+  `devDependencies`, `repository`, `keywords`, `author`, `license`
+- **`mcp.json`**: group servers by type (HTTP first, then stdio)
+- **`devcontainer.json`**: `name`, `image`, `features`, lifecycle commands,
+  `containerEnv`, `customizations`, `mounts`, `remoteUser`
+
+## Governance Constraint Files
+
+Files like `04-governance-constraints.json` in `agent-output/` are generated
+by the governance-discovery-subagent:
+
+- Always use an array of policy objects at the root
+- Include `displayName`, `policyDefinitionId`, `effect`, and `scope` per policy
+- Do not manually edit — regenerate via the governance discovery workflow

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,80 @@
+---
+description: 'Python coding conventions for diagram generation, MCP servers, and tooling scripts'
+applyTo: '**/*.py'
+---
+
+# Python Guidelines
+
+Instructions for writing clean, consistent Python in this repository. Target Python 3.10+
+with Ruff for linting and formatting.
+
+## Project Context
+
+Python is used for three purposes in this repo:
+
+1. **Architecture diagrams** — `diagrams` library scripts in `agent-output/` and `.github/skills/`
+2. **Azure Pricing MCP server** — async `aiohttp`/`starlette` server in `mcp/azure-pricing-mcp/`
+3. **Utility scripts** — Checkov scanning, diagram verification
+
+## Style & Formatting
+
+- **Formatter**: Ruff (`ruff format`) — double quotes, space indentation
+- **Linter**: Ruff with rules: E, W, F, I, B, C4, UP, SIM
+- **Line length**: 120 characters (matches project-wide setting)
+- **Imports**: sorted by isort rules via Ruff — stdlib, third-party, first-party
+- **Quotes**: double quotes for strings
+- **Type hints**: use for function signatures; `pyproject.toml` sets `basic` type checking
+
+## Package Management
+
+- Use `uv` (Astral) as the package manager — installed in devcontainer
+- Root dependencies in `requirements.txt`: `diagrams`, `matplotlib`, `pillow`, `checkov`
+- MCP server dependencies in `mcp/azure-pricing-mcp/pyproject.toml`
+- Use virtual environments: MCP server has its own `.venv`
+
+## Diagram Scripts
+
+Follow the existing pattern for architecture diagram generation:
+
+```python
+"""Brief description of what the diagram shows."""
+
+from diagrams import Cluster, Diagram
+from diagrams.azure.compute import AppServices
+from diagrams.azure.network import FrontDoors
+
+with Diagram("Diagram Title", show=False, filename="output-name", direction="TB"):
+    with Cluster("Resource Group"):
+        # Resources...
+        pass
+```
+
+- Always set `show=False` to prevent auto-opening
+- Use `direction="TB"` (top-to-bottom) for consistency
+- Group resources in `Cluster` blocks matching Azure resource groups
+- Set explicit `filename` parameter to control output location
+
+## Async Patterns (MCP Server)
+
+The Azure Pricing MCP server uses async patterns:
+
+- Use `async def` with `await` — never mix sync and async I/O
+- Use `aiohttp.ClientSession` for HTTP requests — create once, reuse
+- Use `cachetools.TTLCache` for pricing data caching
+- Handle `azure.identity` credential errors gracefully with fallback
+
+## Conventions
+
+- Use `snake_case` for functions, variables, and modules
+- Use `PascalCase` for classes
+- Use `UPPER_SNAKE_CASE` for constants
+- Prefer f-strings over `.format()` or `%` formatting
+- Use pathlib `Path` for new code — existing scripts may use `os.path`
+- Use context managers (`with`) for file and network operations
+
+## Testing
+
+- Test framework: `pytest` with `pytest-asyncio` for async tests
+- Mock framework: `pytest-mock`
+- Tests live alongside source in `tests/` subdirectories
+- Use `@pytest.mark.asyncio` for async test functions

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -7,10 +7,12 @@ domain-specific knowledge modules that activate automatically based on prompt ke
 
 ### Category 1: Azure Conventions
 
-| Skill            | Description                                         | Triggers                                   |
-| ---------------- | --------------------------------------------------- | ------------------------------------------ |
-| `azure-defaults` | Azure conventions, naming, AVM, WAF, pricing, tags  | "azure defaults", "naming", "AVM"          |
-| `azure-artifacts` | Template H2 structures, styling, generation rules  | "generate documentation", "create runbook" |
+| Skill                    | Description                                         | Triggers                                       |
+| ------------------------ | --------------------------------------------------- | ---------------------------------------------- |
+| `azure-defaults`         | Azure conventions, naming, AVM, WAF, pricing, tags  | "azure defaults", "naming", "AVM"              |
+| `azure-artifacts`        | Template H2 structures, styling, generation rules   | "generate documentation", "create runbook"     |
+| `azure-bicep-patterns`   | Reusable Bicep patterns (hub-spoke, PE, diagnostics) | "bicep pattern", "private endpoint", "hub-spoke" |
+| `azure-troubleshooting`  | KQL templates, health checks, remediation playbooks  | "diagnose", "troubleshoot", "health check"      |
 
 ### Category 2: Document Creation
 
@@ -27,6 +29,17 @@ domain-specific knowledge modules that activate automatically based on prompt ke
 | `git-commit`          | Create conventional commit messages                 | "commit", "git commit"                          |
 | `docs-writer`         | Repo-aware documentation maintenance                | "update docs", "check staleness"                |
 | `make-skill-template` | Create new skills from template                     | "create skill", "new skill"                     |
+
+### Category 4: Microsoft Documentation
+
+> These skills require the Microsoft Learn MCP Server (`https://learn.microsoft.com/api/mcp`)
+> configured in `.vscode/mcp.json`.
+
+| Skill                        | Description                                                        | Triggers                                          |
+| ---------------------------- | ------------------------------------------------------------------ | ------------------------------------------------- |
+| `microsoft-docs`             | Query official Microsoft/Azure docs for concepts, tutorials, limits | "look up docs", "find documentation", "learn.microsoft.com" |
+| `microsoft-code-reference`   | Verify SDK methods, find working code samples, troubleshoot errors | "verify API", "find code sample", "SDK reference" |
+| `microsoft-skill-creator`    | Create new hybrid skills for any Microsoft technology              | "create microsoft skill", "new skill for Azure"  |
 
 ## Usage
 

--- a/.github/skills/azure-bicep-patterns/SKILL.md
+++ b/.github/skills/azure-bicep-patterns/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: azure-bicep-patterns
+description: Common Azure Bicep infrastructure patterns including hub-spoke networking, private endpoints, diagnostic settings, conditional deployments, and AVM module composition. Use when designing or generating Bicep templates that combine multiple Azure resources into repeatable patterns.
+compatibility: Requires Azure CLI with Bicep extension
+---
+
+# Azure Bicep Patterns Skill
+
+Reusable infrastructure patterns for Azure Bicep templates. These patterns complement
+the `bicep-code-best-practices.instructions.md` (style rules) and `azure-defaults`
+skill (naming, tags, regions) with composable architecture building blocks.
+
+---
+
+## Quick Reference
+
+| Pattern                  | When to Use                                     |
+| ------------------------ | ----------------------------------------------- |
+| Hub-Spoke Networking     | Multi-workload environments with shared services |
+| Private Endpoint Wiring  | Any PaaS service requiring private connectivity  |
+| Diagnostic Settings      | Every deployed resource (mandatory)              |
+| Conditional Deployment   | Optional resources controlled by parameters      |
+| Module Composition       | Breaking main.bicep into reusable modules        |
+| Managed Identity Binding | Any service-to-service authentication            |
+| What-If Interpretation   | Pre-deployment validation                        |
+
+---
+
+## Hub-Spoke Networking
+
+Standard pattern for shared services hub with workload spokes:
+
+```bicep
+// main.bicep — hub-spoke orchestration
+module hub 'modules/hub-vnet.bicep' = {
+  name: 'hub-vnet'
+  params: {
+    vnetName: 'vnet-hub-${uniqueSuffix}'
+    addressPrefix: '10.0.0.0/16'
+    subnets: [
+      { name: 'AzureFirewallSubnet', prefix: '10.0.1.0/24' }
+      { name: 'GatewaySubnet', prefix: '10.0.2.0/24' }
+    ]
+    tags: tags
+  }
+}
+
+module spoke 'modules/spoke-vnet.bicep' = {
+  name: 'spoke-vnet-${workloadName}'
+  params: {
+    vnetName: 'vnet-spoke-${workloadName}-${uniqueSuffix}'
+    addressPrefix: spokeAddressPrefix
+    hubVnetId: hub.outputs.resourceId
+    tags: tags
+  }
+}
+```
+
+Key rules:
+
+- Hub contains shared infrastructure (firewall, gateway, DNS)
+- Spokes peer to hub — never to each other directly
+- Use `hubVnetId` output to wire peering in spoke modules
+- Apply NSGs per subnet, not per VNet
+
+---
+
+## Private Endpoint Wiring
+
+Standard three-resource pattern for private connectivity:
+
+```bicep
+// Private endpoint for a PaaS service
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2024-01-01' = {
+  name: 'pe-${serviceName}-${uniqueSuffix}'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: subnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'plsc-${serviceName}'
+        properties: {
+          privateLinkServiceId: targetResourceId
+          groupIds: [groupId]
+        }
+      }
+    ]
+  }
+}
+
+resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-01-01' = {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config'
+        properties: {
+          privateDnsZoneId: privateDnsZoneId
+        }
+      }
+    ]
+  }
+}
+```
+
+Group IDs by service type:
+
+| Service          | Group ID       | DNS Zone                                  |
+| ---------------- | -------------- | ----------------------------------------- |
+| Storage Blob     | `blob`         | `privatelink.blob.core.windows.net`       |
+| Storage Table    | `table`        | `privatelink.table.core.windows.net`      |
+| Key Vault        | `vault`        | `privatelink.vaultcore.azure.net`         |
+| SQL Server       | `sqlServer`    | `privatelink.database.windows.net`        |
+| Cosmos DB        | `Sql`          | `privatelink.documents.azure.com`         |
+| App Service      | `sites`        | `privatelink.azurewebsites.net`           |
+| Event Hub        | `namespace`    | `privatelink.servicebus.windows.net`      |
+| Container Reg    | `registry`     | `privatelink.azurecr.io`                  |
+
+---
+
+## Diagnostic Settings
+
+Every resource must send logs and metrics to a workspace:
+
+```bicep
+// Pass workspace NAME (not ID) to modules — resolve inside with existing keyword
+param logAnalyticsWorkspaceName string
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
+resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'diag-${parentResourceName}'
+  scope: parentResource
+  properties: {
+    workspaceId: workspace.id
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+```
+
+- Use `categoryGroup: 'allLogs'` instead of listing individual categories
+- Always include `AllMetrics`
+- Pass workspace **name** not ID — use `existing` keyword to resolve
+
+---
+
+## Conditional Deployment
+
+Use parameters to control optional resource deployment:
+
+```bicep
+@description('Deploy a Redis cache for session state')
+param deployRedis bool = false
+
+module redis 'modules/redis.bicep' = if (deployRedis) {
+  name: 'redis-cache'
+  params: {
+    name: 'redis-${projectName}-${environment}-${uniqueSuffix}'
+    location: location
+    tags: tags
+  }
+}
+
+// Conditional output — empty string when not deployed
+output redisHostName string = deployRedis ? redis.outputs.hostName : ''
+```
+
+- Use `bool` parameters with sensible defaults
+- Guard outputs with ternary expressions
+- Group related optional resources (e.g., `deployMonitoring` enables workspace + alerts + dashboard)
+
+---
+
+## Module Composition
+
+Standard module interface pattern — every module follows this contract:
+
+```bicep
+// modules/storage.bicep
+@description('Storage account name (max 24 chars)')
+param name string
+
+@description('Azure region')
+param location string
+
+@description('Resource tags')
+param tags object
+
+@description('Log Analytics workspace name for diagnostics')
+param logAnalyticsWorkspaceName string
+
+// ... resource definition ...
+
+// MANDATORY outputs
+@description('Resource ID of the storage account')
+output resourceId string = storageAccount.id
+
+@description('Name of the storage account')
+output resourceName string = storageAccount.name
+
+@description('Principal ID of the managed identity (empty if none)')
+output principalId string = storageAccount.identity.?principalId ?? ''
+```
+
+Module conventions:
+
+- Every module accepts `name`, `location`, `tags`, `logAnalyticsWorkspaceName`
+- Every module outputs `resourceId`, `resourceName`, `principalId`
+- Use `@description` on all parameters and outputs
+- Use AVM modules when available — wrap with project-specific defaults if needed
+
+---
+
+## Managed Identity Binding
+
+Standard pattern for granting service-to-service access:
+
+```bicep
+// Grant App Service access to Key Vault secrets
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, appService.id, keyVaultSecretsUserRoleId)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      keyVaultSecretsUserRoleId
+    )
+    principalId: appService.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+```
+
+Common role definition IDs:
+
+| Role                        | ID                                     |
+| --------------------------- | -------------------------------------- |
+| Key Vault Secrets User      | `4633458b-17de-408a-b874-0445c86b69e6` |
+| Storage Blob Data Reader    | `2a2b9908-6ea1-4ae2-8e65-a410df84e7d1` |
+| Storage Blob Data Contrib   | `ba92f5b4-2d11-453d-a403-e96b0029c9fe` |
+| Cosmos DB Account Reader    | `fbdf93bf-df7d-467e-a4d2-9458aa1360c8` |
+| SQL DB Contributor          | `9b7fa17d-e63e-47b0-bb0a-15c516ac86ec` |
+
+- Always use `guid()` for deterministic, idempotent assignment names
+- Set `principalType: 'ServicePrincipal'` for managed identities
+- Scope to the narrowest resource possible
+
+---
+
+## What-If Interpretation
+
+Before deploying, always run what-if to preview changes:
+
+```bash
+az deployment group what-if \
+  --resource-group "$rgName" \
+  --template-file main.bicep \
+  --parameters main.bicepparam \
+  --no-pretty-print
+```
+
+Interpret results:
+
+| Change Type  | Icon   | Action Required                                |
+| ------------ | ------ | ---------------------------------------------- |
+| Create       | green  | New resource — verify name and configuration   |
+| Modify       | yellow | Property change — check for breaking changes   |
+| Delete       | red    | Resource removal — confirm intentional         |
+| NoChange     | grey   | Idempotent — no action needed                  |
+| Deploy       | blue   | Child resource deployment                      |
+| Ignore       | grey   | Read-only property change — safe to ignore     |
+
+Red flags to catch: unexpected deletes, SKU downgrades, public access changes,
+authentication mode changes, or identity removal.
+
+---
+
+## Learn More
+
+For patterns not covered here, query official documentation:
+
+| Topic                    | How to Find                                                                |
+| ------------------------ | -------------------------------------------------------------------------- |
+| AVM module catalog       | `microsoft_docs_search(query="Azure Verified Modules registry Bicep")`     |
+| Resource type schema     | `microsoft_docs_search(query="{resource-type} Bicep template reference")` |
+| Networking patterns      | `microsoft_docs_search(query="Azure hub-spoke network topology Bicep")`   |
+| Security baseline        | `microsoft_docs_search(query="{service} security baseline")`              |

--- a/.github/skills/azure-troubleshooting/SKILL.md
+++ b/.github/skills/azure-troubleshooting/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: azure-troubleshooting
+description: Azure resource troubleshooting patterns including KQL templates, metric thresholds, health checks, and remediation playbooks. Use when diagnosing unhealthy Azure resources or building diagnostic workflows.
+compatibility: Requires Azure CLI with resource-graph extension
+---
+
+# Azure Troubleshooting Skill
+
+Structured diagnostic patterns for Azure resource health assessment and
+remediation. Provides KQL templates, metric baselines, severity classifications,
+and per-resource-type diagnostic workflows.
+
+---
+
+## Quick Reference
+
+| Capability              | Description                                                      |
+| ----------------------- | ---------------------------------------------------------------- |
+| Resource Discovery      | Azure Resource Graph queries to find and inventory resources     |
+| Health Checks           | Per-resource-type diagnostic commands and metric thresholds      |
+| KQL Templates           | Log Analytics queries for common failure scenarios               |
+| Severity Classification | Standardised impact/urgency mapping for findings                 |
+| Remediation Playbooks   | Step-by-step resolution for common issues                        |
+
+---
+
+## Resource Discovery via Resource Graph
+
+Find resources before diagnosing them:
+
+```kql
+// List all resources in a resource group with their health status
+resources
+| where resourceGroup == '{resourceGroupName}'
+| project name, type, location, properties.provisioningState
+| order by type asc, name asc
+```
+
+```kql
+// Find resources with non-Succeeded provisioning state
+resources
+| where resourceGroup == '{resourceGroupName}'
+| where properties.provisioningState != 'Succeeded'
+| project name, type, properties.provisioningState
+```
+
+```kql
+// Inventory resources by type
+resources
+| where resourceGroup == '{resourceGroupName}'
+| summarize count() by type
+| order by count_ desc
+```
+
+---
+
+## Diagnostic Settings Check
+
+Verify every resource has diagnostic settings configured:
+
+```bash
+# List resources missing diagnostic settings
+az monitor diagnostic-settings list \
+  --resource "$resourceId" \
+  --query "[].{name:name, workspace:workspaceId}" \
+  --output table
+```
+
+If no diagnostic settings exist, create them using the pattern from the
+`azure-bicep-patterns` skill (Diagnostic Settings section).
+
+---
+
+## Per-Resource Health Checks
+
+### App Service / Web Apps
+
+| Check                  | Command / Query                                                          | Healthy Threshold          |
+| ---------------------- | ------------------------------------------------------------------------ | -------------------------- |
+| HTTP health            | `az webapp show --name {name} --query state`                             | `Running`                  |
+| Response time          | KQL: `AzureMetrics \| where MetricName == "HttpResponseTime"`            | p95 < 2 seconds            |
+| HTTP 5xx rate          | KQL: `AzureMetrics \| where MetricName == "Http5xx"`                     | < 1% of total requests     |
+| CPU usage              | KQL: `AzureMetrics \| where MetricName == "CpuPercentage"`              | < 80% sustained            |
+| Memory usage           | KQL: `AzureMetrics \| where MetricName == "MemoryPercentage"`           | < 85% sustained            |
+| App Service Plan SKU   | `az appservice plan show --name {plan} --query sku`                      | Matches architecture spec  |
+
+```kql
+// App Service error rate over last 24h
+AzureMetrics
+| where ResourceId contains '{appName}'
+| where MetricName == 'Http5xx'
+| where TimeGenerated > ago(24h)
+| summarize Total5xx = sum(Total) by bin(TimeGenerated, 1h)
+| order by TimeGenerated desc
+```
+
+### Virtual Machines
+
+| Check             | Command / Query                                                         | Healthy Threshold        |
+| ----------------- | ----------------------------------------------------------------------- | ------------------------ |
+| Power state       | `az vm get-instance-view --name {name} --query instanceView.statuses`   | `PowerState/running`     |
+| CPU utilisation   | KQL: `Perf \| where ObjectName == "Processor"`                          | < 85% sustained          |
+| Available memory  | KQL: `Perf \| where ObjectName == "Memory"`                             | > 20% free               |
+| Disk latency      | KQL: `Perf \| where CounterName == "Avg. Disk sec/Transfer"`           | < 20 ms                  |
+| Boot diagnostics  | `az vm boot-diagnostics get-boot-log --name {name}`                     | No kernel panic / errors |
+
+```kql
+// VM CPU spikes in last 6h
+Perf
+| where Computer == '{vmName}'
+| where ObjectName == 'Processor' and CounterName == '% Processor Time'
+| where TimeGenerated > ago(6h)
+| summarize AvgCPU = avg(CounterValue), MaxCPU = max(CounterValue) by bin(TimeGenerated, 5m)
+| where MaxCPU > 85
+| order by TimeGenerated desc
+```
+
+### Storage Accounts
+
+| Check              | Command / Query                                                          | Healthy Threshold          |
+| ------------------ | ------------------------------------------------------------------------ | -------------------------- |
+| Availability       | KQL: `AzureMetrics \| where MetricName == "Availability"`               | > 99.9%                    |
+| E2E latency        | KQL: `AzureMetrics \| where MetricName == "SuccessE2ELatency"`          | < 100 ms (hot), <1s (cool)|
+| Throttling         | KQL: `StorageBlobLogs \| where StatusCode == 503`                        | 0 in normal operation      |
+| Used capacity      | `az storage account show --name {name} --query primaryEndpoints`         | < 80% quota                |
+| HTTPS enforcement  | `az storage account show --name {name} --query enableHttpsTrafficOnly`   | `true`                     |
+
+### SQL Database
+
+| Check              | Command / Query                                                          | Healthy Threshold          |
+| ------------------ | ------------------------------------------------------------------------ | -------------------------- |
+| DTU/vCore usage    | KQL: `AzureMetrics \| where MetricName == "dtu_consumption_percent"`     | < 80% sustained            |
+| Connection failures| KQL: `AzureMetrics \| where MetricName == "connection_failed"`           | < 5 per 5-min window       |
+| Deadlocks          | KQL: `AzureMetrics \| where MetricName == "deadlock"`                    | 0                          |
+| Storage usage      | KQL: `AzureMetrics \| where MetricName == "storage_percent"`             | < 85%                      |
+| Long queries       | `sys.dm_exec_query_stats` via Azure Portal                               | No queries > 30s           |
+
+### Static Web Apps
+
+| Check              | Command / Query                                                          | Healthy Threshold          |
+| ------------------ | ------------------------------------------------------------------------ | -------------------------- |
+| Deployment status  | `az staticwebapp show --name {name} --query defaultHostname`             | Resolves correctly         |
+| Custom domain      | `az staticwebapp hostname list --name {name}`                            | SSL valid, not expired     |
+| Function health    | Check managed function app logs in Log Analytics                         | No 5xx in API routes       |
+
+---
+
+## Severity Classification
+
+Classify every finding with consistent severity:
+
+| Severity | Criteria                                                                | Response Time    |
+| -------- | ----------------------------------------------------------------------- | ---------------- |
+| Critical | Service down, data loss risk, security breach                           | Immediate        |
+| High     | Degraded performance, failing redundancy, auth issues                   | Within 4 hours   |
+| Medium   | Suboptimal configuration, missing best practices, capacity warnings     | Within 24 hours  |
+| Low      | Cosmetic issues, documentation gaps, minor optimisations                | Next sprint      |
+
+---
+
+## Diagnostic Workflow
+
+Follow this six-phase sequence for any resource investigation:
+
+### Phase 1 — Discovery
+
+```bash
+# Get resource details
+az resource show --ids "$resourceId" --query "{name:name, type:type, location:location, sku:sku, tags:tags}"
+```
+
+### Phase 2 — Health Assessment
+
+Run the resource-type-specific health checks from the tables above.
+
+### Phase 3 — Log Analysis
+
+```kql
+// Generic error search — last 24h
+AzureDiagnostics
+| where ResourceId contains '{resourceName}'
+| where TimeGenerated > ago(24h)
+| where Level == 'Error' or Level == 'Warning'
+| summarize Count = count() by Level, OperationName
+| order by Count desc
+```
+
+### Phase 4 — Activity Log Review
+
+```bash
+# Recent operations that may have caused issues
+az monitor activity-log list \
+  --resource-id "$resourceId" \
+  --start-time "$(date -d '24 hours ago' -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --query "[?status.value=='Failed'].{op:operationName.localizedValue, time:eventTimestamp, status:status.value, caller:caller}" \
+  --output table
+```
+
+### Phase 5 — Classification
+
+Rate each finding using the severity table above. Include:
+
+- **Finding**: What is wrong
+- **Severity**: Critical / High / Medium / Low
+- **Evidence**: KQL query result or CLI output
+- **Remediation**: Specific fix steps
+
+### Phase 6 — Report Generation
+
+Structure the diagnostic report as:
+
+```markdown
+## Diagnostic Report: {resource-name}
+
+**Assessment Date**: {date}
+**Assessed By**: InfraOps Diagnose Agent
+**Overall Health**: 🟢 Healthy | 🟡 Degraded | 🔴 Unhealthy
+
+### Findings Summary
+
+| # | Finding | Severity | Status |
+|---|---------|----------|--------|
+| 1 | ...     | High     | Open   |
+
+### Detailed Findings
+
+#### Finding 1: {title}
+...
+
+### Recommended Actions
+1. ...
+```
+
+---
+
+## Common Remediation Playbooks
+
+### High CPU on App Service
+
+1. Check if autoscale is configured — if not, add scale-out rule at 70% CPU
+2. Review Application Insights for slow dependencies
+3. Check for synchronous blocking calls in application code
+4. Consider scaling up the App Service Plan SKU
+
+### Storage Account Throttling
+
+1. Check current request rate against [storage scalability targets](https://learn.microsoft.com/azure/storage/common/scalability-targets-standard-account)
+2. Enable CDN for read-heavy blob workloads
+3. Distribute across multiple storage accounts if partition limits hit
+4. Switch to Premium storage for high-IOPS requirements
+
+### SQL Database DTU Exhaustion
+
+1. Identify top resource-consuming queries via Query Performance Insight
+2. Add missing indexes suggested by Azure SQL advisor
+3. Scale up DTU tier or switch to vCore for more granular control
+4. Review connection pooling settings in application
+
+---
+
+## Learn More
+
+For issues not covered here, query official documentation:
+
+| Topic                    | How to Find                                                                      |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| Service-specific limits  | `microsoft_docs_search(query="{service} limits quotas")`                         |
+| KQL reference            | `microsoft_docs_search(query="KQL quick reference Azure Monitor")`               |
+| Metric definitions       | `microsoft_docs_search(query="{service} supported metrics Azure Monitor")`       |
+| Troubleshooting guides   | `microsoft_docs_search(query="{service} troubleshoot common issues")`            |

--- a/.github/skills/make-skill-template/SKILL.md
+++ b/.github/skills/make-skill-template/SKILL.md
@@ -153,6 +153,109 @@ my-awesome-skill/
 | Description too short    | Add capabilities, triggers, and keywords                 |
 | Assets not found         | Use relative paths from skill root                       |
 
+## Project-Specific Scaffold Templates
+
+When creating skills for *this* project, use one of these skeletons that match
+the conventions already established in the repository.
+
+### Azure Knowledge Skill Skeleton
+
+For skills that teach agents about Azure patterns, conventions, or diagnostics:
+
+```yaml
+---
+name: azure-{topic}
+description: {What it does including Azure context}. Use when {triggers and keywords}.
+compatibility: Requires Azure CLI with Bicep extension
+---
+```
+
+```markdown
+# Azure {Topic} Skill
+
+One-sentence overview of what this skill provides.
+
+---
+
+## Quick Reference
+
+| Pattern / Capability | When to Use |
+| -------------------- | ----------- |
+| ...                  | ...         |
+
+---
+
+## {Pattern/Section Name}
+
+Explanation and code example:
+
+\```bicep
+// example
+\```
+
+---
+
+## Learn More
+
+| Topic | How to Find |
+| ----- | ----------- |
+| ...   | `microsoft_docs_search(query="...")` |
+```
+
+### Integration Skill Skeleton
+
+For skills that wrap external tools, MCP servers, or CLIs:
+
+```yaml
+---
+name: {tool-name}
+description: {What it does}. Use when {triggers}.
+compatibility: Requires {tool/dependency}
+---
+```
+
+```markdown
+# {Tool Name} Skill
+
+Overview of the integration.
+
+---
+
+## Quick Reference
+
+| Tool / Command | Purpose |
+| -------------- | ------- |
+| ...            | ...     |
+
+---
+
+## Workflow
+
+### Step 1: ...
+### Step 2: ...
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+| ----- | -------- |
+| ...   | ...      |
+```
+
+### Checklist: Before Committing a New Skill
+
+- [ ] Folder uses lowercase-hyphenated name matching `name:` field
+- [ ] `description` is a single-line inline string (no YAML block scalars)
+- [ ] `description` includes WHAT, WHEN, and keywords
+- [ ] Body uses `---` horizontal rules between major sections
+- [ ] Tables used for structured data instead of prose lists
+- [ ] Code examples are project-relevant (Bicep, KQL, Azure CLI)
+- [ ] `## Learn More` section references `microsoft_docs_search()` where applicable
+- [ ] Added to `.github/skills/README.md` under the correct category
+- [ ] Added to `.github/copilot-instructions.md` skills table
+- [ ] Wired into consuming agents via mandatory read list
+
 ## References
 
 - Agent Skills official spec: <https://agentskills.io/specification>

--- a/.github/skills/microsoft-code-reference/SKILL.md
+++ b/.github/skills/microsoft-code-reference/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: microsoft-code-reference
+description: Look up Microsoft API references, find working code samples, and verify SDK code is correct. Use when working with Azure SDKs, .NET libraries, or Microsoft APIs—to find the right method, check parameters, get working examples, or troubleshoot errors. Catches hallucinated methods, wrong signatures, and deprecated patterns by querying official docs.
+compatibility: Requires Microsoft Learn MCP Server (https://learn.microsoft.com/api/mcp)
+---
+
+# Microsoft Code Reference
+
+## Tools
+
+| Need                    | Tool                         | Example                                                                          |
+| ----------------------- | ---------------------------- | -------------------------------------------------------------------------------- |
+| API method/class lookup | `microsoft_docs_search`      | `"BlobClient UploadAsync Azure.Storage.Blobs"`                                   |
+| Working code sample     | `microsoft_code_sample_search` | `query: "upload blob managed identity", language: "python"`                    |
+| Full API reference      | `microsoft_docs_fetch`       | Fetch URL from `microsoft_docs_search` (for overloads, full signatures)          |
+
+## Finding Code Samples
+
+Use `microsoft_code_sample_search` to get official, working examples:
+
+```text
+microsoft_code_sample_search(query: "upload file to blob storage", language: "csharp")
+microsoft_code_sample_search(query: "authenticate with managed identity", language: "python")
+microsoft_code_sample_search(query: "send message service bus", language: "javascript")
+```
+
+When to use:
+
+- Before writing code—find a working pattern to follow
+- After errors—compare your code against a known-good sample
+- Unsure of initialization/setup—samples show complete context
+
+## API Lookups
+
+```text
+# Verify method exists (include namespace for precision)
+"BlobClient UploadAsync Azure.Storage.Blobs"
+"GraphServiceClient Users Microsoft.Graph"
+
+# Find class/interface
+"DefaultAzureCredential class Azure.Identity"
+
+# Find correct package
+"Azure Blob Storage NuGet package"
+"azure-storage-blob pip package"
+```
+
+Fetch full page when method has multiple overloads or you need complete parameter details.
+
+## Error Troubleshooting
+
+Use `microsoft_code_sample_search` to find working code samples and compare with your
+implementation. For specific errors, use `microsoft_docs_search` and `microsoft_docs_fetch`:
+
+| Error Type          | Query                                                      |
+| ------------------- | ---------------------------------------------------------- |
+| Method not found    | `"[ClassName] methods [Namespace]"`                        |
+| Type not found      | `"[TypeName] NuGet package namespace"`                     |
+| Wrong signature     | `"[ClassName] [MethodName] overloads"` → fetch full page   |
+| Deprecated warning  | `"[OldType] migration v12"`                                |
+| Auth failure        | `"DefaultAzureCredential troubleshooting"`                 |
+| 403 Forbidden       | `"[ServiceName] RBAC permissions"`                         |
+
+## When to Verify
+
+Always verify when:
+
+- Method name seems "too convenient" (`UploadFile` vs actual `Upload`)
+- Mixing SDK versions (v11 `CloudBlobClient` vs v12 `BlobServiceClient`)
+- Package name doesn't follow conventions (`Azure.*` for .NET, `azure-*` for Python)
+- Using an API for the first time
+
+## Validation Workflow
+
+Before generating code using Microsoft SDKs, verify it's correct:
+
+1. **Confirm method or package exists** — `microsoft_docs_search(query: "[ClassName] [MethodName] [Namespace]")`
+2. **Fetch full details** (for overloads/complex params) — `microsoft_docs_fetch(url: "...")`
+3. **Find working sample** — `microsoft_code_sample_search(query: "[task]", language: "[lang]")`
+
+For simple lookups, step 1 alone may suffice. For complex API usage, complete all three steps.

--- a/.github/skills/microsoft-docs/SKILL.md
+++ b/.github/skills/microsoft-docs/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: microsoft-docs
+description: Query official Microsoft documentation to understand concepts, find tutorials, and learn how services work. Use for Azure, .NET, Microsoft 365, Windows, Power Platform, and all Microsoft technologies. Get accurate, current information from learn.microsoft.com—architecture overviews, quickstarts, configuration guides, limits, and best practices.
+compatibility: Requires Microsoft Learn MCP Server (https://learn.microsoft.com/api/mcp)
+---
+
+# Microsoft Docs
+
+## Tools
+
+| Tool                   | Use For                                                    |
+| ---------------------- | ---------------------------------------------------------- |
+| `microsoft_docs_search` | Find documentation—concepts, guides, tutorials, configuration |
+| `microsoft_docs_fetch`  | Get full page content (when search excerpts aren't enough) |
+
+## When to Use
+
+- **Understanding concepts** — "How does Cosmos DB partitioning work?"
+- **Learning a service** — "Azure Functions overview", "Container Apps architecture"
+- **Finding tutorials** — "quickstart", "getting started", "step-by-step"
+- **Configuration options** — "App Service configuration settings"
+- **Limits & quotas** — "Azure OpenAI rate limits", "Service Bus quotas"
+- **Best practices** — "Azure security best practices"
+
+## Query Effectiveness
+
+Good queries are specific:
+
+```text
+# ❌ Too broad
+"Azure Functions"
+
+# ✅ Specific
+"Azure Functions Python v2 programming model"
+"Cosmos DB partition key design best practices"
+"Container Apps scaling rules KEDA"
+```
+
+Include context:
+
+- **Version** when relevant (`.NET 8`, `EF Core 8`)
+- **Task intent** (`quickstart`, `tutorial`, `overview`, `limits`)
+- **Platform** for multi-platform docs (`Linux`, `Windows`)
+
+## When to Fetch Full Page
+
+Fetch after search when:
+
+- **Tutorials** — need complete step-by-step instructions
+- **Configuration guides** — need all options listed
+- **Deep dives** — user wants comprehensive coverage
+- **Search excerpt is cut off** — full context needed
+
+## Why Use This
+
+- **Accuracy** — live docs, not training data that may be outdated
+- **Completeness** — tutorials have all steps, not fragments
+- **Authority** — official Microsoft documentation

--- a/.github/skills/microsoft-skill-creator/SKILL.md
+++ b/.github/skills/microsoft-skill-creator/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: microsoft-skill-creator
+description: Create agent skills for Microsoft technologies using Learn MCP tools. Use when users want to create a skill that teaches agents about any Microsoft technology, library, framework, or service (Azure, .NET, M365, VS Code, Bicep, etc.). Investigates topics deeply, then generates a hybrid skill storing essential knowledge locally while enabling dynamic deeper investigation.
+compatibility: Requires Microsoft Learn MCP Server (https://learn.microsoft.com/api/mcp)
+---
+
+# Microsoft Skill Creator
+
+Create hybrid skills for Microsoft technologies that store essential knowledge locally while
+enabling dynamic Learn MCP lookups for deeper details.
+
+## About Skills
+
+Skills are modular packages that extend agent capabilities with specialized knowledge and
+workflows. A skill transforms a general-purpose agent into a specialized one for a specific domain.
+
+### Skill Structure
+
+```text
+skill-name/
+├── SKILL.md (required)     # Frontmatter (name, description) + instructions
+├── references/             # Documentation loaded into context as needed
+├── sample_codes/           # Working code examples
+└── assets/                 # Files used in output (templates, etc.)
+```
+
+### Key Principles
+
+- **Frontmatter is critical**: `name` and `description` determine when the skill triggers—be clear
+  and comprehensive
+- **Concise is key**: Only include what agents don't already know; context window is shared
+- **No duplication**: Information lives in SKILL.md OR reference files, not both
+
+## Learn MCP Tools
+
+| Tool                         | Purpose              | When to Use                    |
+| ---------------------------- | -------------------- | ------------------------------ |
+| `microsoft_docs_search`      | Search official docs | First pass discovery, finding topics |
+| `microsoft_docs_fetch`       | Get full page content | Deep dive into important pages |
+| `microsoft_code_sample_search` | Find code examples | Get implementation patterns    |
+
+## Creation Process
+
+### Step 1: Investigate the Topic
+
+Build deep understanding using Learn MCP tools in three phases:
+
+**Phase 1 - Scope Discovery:**
+
+```text
+microsoft_docs_search(query="{technology} overview what is")
+microsoft_docs_search(query="{technology} concepts architecture")
+microsoft_docs_search(query="{technology} getting started tutorial")
+```
+
+**Phase 2 - Core Content:**
+
+```text
+microsoft_docs_fetch(url="...")  # Fetch pages from Phase 1
+microsoft_code_sample_search(query="{technology}", language="{lang}")
+```
+
+**Phase 3 - Depth:**
+
+```text
+microsoft_docs_search(query="{technology} best practices")
+microsoft_docs_search(query="{technology} troubleshooting errors")
+```
+
+#### Investigation Checklist
+
+After investigating, verify:
+
+- [ ] Can explain what the technology does in one paragraph
+- [ ] Identified 3-5 key concepts
+- [ ] Have working code for basic usage
+- [ ] Know the most common API patterns
+- [ ] Have search queries for deeper topics
+
+### Step 2: Clarify with User
+
+Present findings and ask:
+
+1. "I found these key areas: [list]. Which are most important?"
+2. "What tasks will agents primarily perform with this skill?"
+3. "Which programming language should code samples prioritize?"
+
+### Step 3: Generate the Skill
+
+Use the appropriate template based on technology type:
+
+| Technology Type                    | Template          |
+| ---------------------------------- | ----------------- |
+| Client library, NuGet/npm package  | SDK/Library       |
+| Azure resource                     | Azure Service     |
+| App development framework          | Framework/Platform |
+| REST API, protocol                 | API/Protocol      |
+
+#### Generated Skill Structure
+
+```text
+{skill-name}/
+├── SKILL.md                    # Core knowledge + Learn MCP guidance
+├── references/                 # Detailed local documentation (if needed)
+└── sample_codes/               # Working code examples
+    ├── getting-started/
+    └── common-patterns/
+```
+
+### Step 4: Balance Local vs Dynamic Content
+
+**Store locally when:**
+
+- Foundational (needed for any task)
+- Frequently accessed
+- Stable (won't change)
+- Hard to find via search
+
+**Keep dynamic when:**
+
+- Exhaustive reference (too large)
+- Version-specific
+- Situational (specific tasks only)
+- Well-indexed (easy to search)
+
+#### Content Guidelines
+
+| Content Type          | Local             | Dynamic              |
+| --------------------- | ----------------- | -------------------- |
+| Core concepts (3-5)   | ✅ Full           |                      |
+| Hello world code      | ✅ Full           |                      |
+| Common patterns (3-5) | ✅ Full           |                      |
+| Top API methods       | Signature + example | Full docs via fetch |
+| Best practices        | Top 5 bullets     | Search for more      |
+| Troubleshooting       |                   | Search queries       |
+| Full API reference    |                   | Doc links            |
+
+### Step 5: Validate
+
+1. Review: Is local content sufficient for common tasks?
+2. Test: Do suggested search queries return useful results?
+3. Verify: Do code samples run without errors?
+
+## Common Investigation Patterns
+
+### For SDKs/Libraries
+
+```text
+"{name} overview" → purpose, architecture
+"{name} getting started quickstart" → setup steps
+"{name} API reference" → core classes/methods
+"{name} samples examples" → code patterns
+"{name} best practices performance" → optimization
+```
+
+### For Azure Services
+
+```text
+"{service} overview features" → capabilities
+"{service} quickstart {language}" → setup code
+"{service} REST API reference" → endpoints
+"{service} SDK {language}" → client library
+"{service} pricing limits quotas" → constraints
+```
+
+### For Frameworks/Platforms
+
+```text
+"{framework} architecture concepts" → mental model
+"{framework} project structure" → conventions
+"{framework} tutorial walkthrough" → end-to-end flow
+"{framework} configuration options" → customization
+```
+
+## Example: Creating a "Semantic Kernel" Skill
+
+### Investigation
+
+```text
+microsoft_docs_search(query="semantic kernel overview")
+microsoft_docs_search(query="semantic kernel plugins functions")
+microsoft_code_sample_search(query="semantic kernel", language="csharp")
+microsoft_docs_fetch(url="https://learn.microsoft.com/semantic-kernel/overview/")
+```
+
+### Generated Skill
+
+```text
+semantic-kernel/
+├── SKILL.md
+└── sample_codes/
+    ├── getting-started/
+    │   └── hello-kernel.cs
+    └── common-patterns/
+        ├── chat-completion.cs
+        └── function-calling.cs
+```
+
+### Generated SKILL.md
+
+```markdown
+---
+name: semantic-kernel
+description: Build AI agents with Microsoft Semantic Kernel. Use for LLM-powered apps
+  with plugins, planners, and memory in .NET or Python.
+---
+
+# Semantic Kernel
+
+Orchestration SDK for integrating LLMs into applications with plugins, planners, and memory.
+
+## Key Concepts
+
+- **Kernel**: Central orchestrator managing AI services and plugins
+- **Plugins**: Collections of functions the AI can call
+- **Planner**: Sequences plugin functions to achieve goals
+- **Memory**: Vector store integration for RAG patterns
+
+## Quick Start
+
+See `sample_codes/getting-started/hello-kernel.cs`
+
+## Learn More
+
+| Topic             | How to Find                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| Plugin development | `microsoft_docs_search(query="semantic kernel plugins custom functions")`         |
+| Planners          | `microsoft_docs_search(query="semantic kernel planner")`                           |
+| Memory            | `microsoft_docs_fetch(url="https://learn.microsoft.com/en-us/semantic-kernel/frameworks/agent/agent-memory")` |
+```

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -4,6 +4,10 @@
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"
     },
+    "microsoft-learn": {
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
+    },
     "azure-pricing": {
       "type": "stdio",
       "command": "${workspaceFolder}/mcp/azure-pricing-mcp/.venv/bin/python",


### PR DESCRIPTION
## Description

Adds Microsoft Learn MCP integration, five new reusable agent skills, and three language-specific instruction files. Agents can now query official Microsoft documentation, find working code samples, and follow standardized coding conventions for JavaScript, Python, and JSON.

## Type of Change

- [x] 🤖 Agent definition update (.github/agents/)
- [x] 📝 Documentation update
- [x] ⚙️ Configuration/workflow change

## Workflow Used

- [x] Copilot Coding Agent (autonomous)

## Changes Made

**Files added:**
- `.github/instructions/javascript.instructions.md`
- `.github/instructions/json.instructions.md`
- `.github/instructions/python.instructions.md`
- `.github/skills/azure-bicep-patterns/SKILL.md`
- `.github/skills/azure-troubleshooting/SKILL.md`
- `.github/skills/microsoft-docs/SKILL.md`
- `.github/skills/microsoft-code-reference/SKILL.md`
- `.github/skills/microsoft-skill-creator/SKILL.md`

**Files modified:**
- `.vscode/mcp.json` — Added Microsoft Learn MCP server
- `.github/copilot-instructions.md` — Expanded skills table
- `.github/agents/03-architect.agent.md` — Wired microsoft-docs skill
- `.github/agents/05-bicep-planner.agent.md` — Wired azure-bicep-patterns skill
- `.github/agents/06-bicep-code-generator.agent.md` — Wired microsoft-code-reference + azure-bicep-patterns
- `.github/agents/09-diagnose.agent.md` — Wired microsoft-docs + azure-troubleshooting

## Testing Performed

- [x] Pre-commit hooks passed (agent-frontmatter, instruction-frontmatter, markdown-lint, commitlint)
- [x] All 23 instruction files valid
- [x] All 14 agent files valid
- [x] 0 markdown lint errors