### PR TITLE
fix(docs): post-merge lint fixes — MD013 line length and dead githubstatus link

### DIFF
--- a/.github/agents/02-requirements.agent.md
+++ b/.github/agents/02-requirements.agent.md
@@ -214,8 +214,11 @@ its questions now.
 4. **Read** `.github/skills/azure-artifacts/templates/PROJECT-README.template.md`
    — project README template (mandatory first artifact for every new project)
 
-These skills are your single source of truth. Do NOT use hardcoded values. 2. Run research via subagent for any Azure documentation gaps 3. Generate full requirements document matching H2 structure from
-azure-artifacts skill 4. Present draft, iterate on feedback, save on approval
+These skills are your single source of truth. Do NOT use hardcoded values.
+
+1. Run research via subagent for any Azure documentation gaps
+2. Generate full requirements document matching H2 structure from the azure-artifacts skill
+3. Present draft, iterate on feedback, save on approval
 
 > Project name, environments, and IaC tool are already captured in Phases 1-2.
 > Phase 5 focuses on final document generation and review.

--- a/docs/presenter/workshop-checklist.md
+++ b/docs/presenter/workshop-checklist.md
@@ -243,7 +243,7 @@
 
 ### Copilot Not Responding
 
-1. Check Copilot status: <https://githubstatus.com>
+1. Check Copilot status: <https://www.githubstatus.com>
 2. Try: Sign out and back in to Copilot
 3. Fallback: Use pre-recorded demo clips
 4. Continue with explanation of what WOULD happen


### PR DESCRIPTION
## Description

Two lint issues found after merging `tf-dev` → `main` (PR #185). Both were pre-existing issues that became visible on `main` for the first time.

## Changes

- **`.github/agents/02-requirements.agent.md`** — Fixed MD013 line-length violation (line 217 was 202 chars). Numbered list items that were collapsed onto one long line have been restored as proper list items.
- **`docs/presenter/workshop-checklist.md`** — Fixed dead link `https://githubstatus.com` → `https://www.githubstatus.com` (the bare domain has no DNS resolution; `www.` prefix is required).

## Type of Change

- [x] 🐛 Bug fix

## Testing Performed

- [x] `npm run validate:all` passes with `✅ All validations passed`
- [x] `npm run lint:md` — 0 errors
- [x] `npm run lint:links:docs` — 0 dead links
