### PR TITLE
build(devcontainer): replace tfsec with checkov, pin tflint to v0.61.0

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -13,8 +13,8 @@ It includes all required tools, extensions, and configurations to build Azure in
 
 - **Azure CLI** (latest) with Bicep CLI
 - **Bicep** for Azure infrastructure
-- **Terraform** (latest) with **tfsec** security scanner
-- **Checkov** - Infrastructure security scanner
+- **Terraform** (latest) with **TFLint** (pinned to v0.61.0)
+- **Checkov** - Infrastructure security scanner (replaces tfsec, which is archived and has no ARM64 support)
 - **Go** (latest) — used to install the Terraform MCP Server binary
 
 ### Scripting & Automation

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,8 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/terraform:1": {
-      "installTFsec": true
+      "tflint": "0.61.0",
+      "installTFsec": false
     },
     "ghcr.io/devcontainers/features/go:1": {}
   },


### PR DESCRIPTION
## Summary

Replaces the archived `tfsec` security scanner with `checkov` and pins TFLint to `v0.61.0` in the devcontainer configuration.

## Changes

- Pin TFLint to `v0.61.0` in the devcontainer terraform feature config
- Set `installTFsec: false` (tfsec is archived and has no ARM64 support)
- Checkov is already installed via `uv` as the security scanner replacement
- Update `.devcontainer/README.md` to accurately reflect the tooling

## Why

`tfsec` was archived in 2024 with no ARM64 support, causing silent failures in devcontainer builds on ARM64 hosts (e.g., Apple Silicon, AWS Graviton). `checkov` is the recommended replacement and is already wired into the `post-create.sh` workflow.

## Context

This branch (`ctx-opt/implement-recommendations`) also includes session-resume context optimization work (committed earlier). All changes are greenfield additions with no breaking impact on existing workflows.