### PR TITLE
docs: set VS Code User Settings as only supported GH_TOKEN method

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -78,10 +78,16 @@ It includes all required tools, extensions, and configurations to build Azure in
 ### GitHub CLI Authentication (GH_TOKEN)
 
 HTTPS-based `gh auth login` can fail inside devcontainers on some platforms (Windows, ARM, WSL 2).
-The recommended approach is a **Personal Access Token (PAT)** set as a host environment variable.
+The **only supported** approach is a **Personal Access Token (PAT)** set in **VS Code User Settings**.
 The container reads it automatically — no `gh auth login` required inside the container.
 
-#### Create a Fine-Grained PAT
+> **Why not shell exports?** Setting `GH_TOKEN` in `~/.bashrc`, `~/.profile`, or PowerShell
+> environment variables does **not** propagate reliably into devcontainers. VS Code reads
+> `${localEnv:GH_TOKEN}` from its own process environment, which only inherits from the
+> specific shell session that launched it. The VS Code settings method is deterministic and
+> survives rebuilds, reboots, and IDE restarts.
+
+#### Step 1: Create a Fine-Grained PAT
 
 > **Yes, fine-grained PATs work here.** The `gh` CLI fully supports fine-grained tokens
 > (`github_pat_...`) via the `GH_TOKEN` environment variable for all repository-scoped operations.
@@ -102,30 +108,33 @@ The container reads it automatically — no `gh auth login` required inside the 
 
 6. Copy the token (`github_pat_...`)
 
-#### Set it on your host machine (once per machine)
+#### Step 2: Add to VS Code User Settings (once per machine)
 
-```bash
-# Linux / macOS / WSL 2 — add to ~/.bashrc, ~/.zshrc, or ~/.profile, then reload
-export GH_TOKEN=github_pat_your_token_here
+1. Open VS Code Settings: **Ctrl+,** (or **Cmd+,** on macOS)
+2. Click the **Open Settings (JSON)** icon (top-right)
+3. Add this entry (replace the placeholder with your actual token):
+
+```jsonc
+"terminal.integrated.env.linux": { "GH_TOKEN": "github_pat_your_token_here" }
 ```
 
-```powershell
-# Windows PowerShell — user-scoped, survives reboots
-[System.Environment]::SetEnvironmentVariable('GH_TOKEN', 'github_pat_your_token_here', 'User')
-```
+<!-- markdownlint-disable MD029 -->
 
-The devcontainer forwards `GH_TOKEN` from your host automatically
-(`"GH_TOKEN": "${localEnv:GH_TOKEN}"` in `devcontainer.json`). If the variable is not set,
-`gh` falls back to its normal interactive auth flow.
+4. Save the file
+5. Rebuild the devcontainer: **F1 → Dev Containers: Rebuild Container**
+<!-- markdownlint-enable MD029 -->
 
-#### Verify inside the container
+The devcontainer forwards `GH_TOKEN` from VS Code's environment automatically
+(`"GH_TOKEN": "${localEnv:GH_TOKEN}"` in `devcontainer.json`).
+
+#### Step 3: Verify inside the container
 
 ```bash
 gh auth status
 # Expected: ✓ Logged in to github.com as <your-username> (token)
 ```
 
-> **Token rotation**: When your PAT expires, update the env var on your host machine and
+> **Token rotation**: When your PAT expires, update the value in VS Code User Settings and
 > rebuild the container (`F1 → Dev Containers: Rebuild Container`).
 
 ### First-Time Setup (Inside Container)
@@ -149,10 +158,10 @@ cd ../../infra/bicep/ && tree -L 2
 
 ### Pre-configured Environment Variables
 
-| Variable                  | Value                  | Purpose                                        |
-| ------------------------- | ---------------------- | ---------------------------------------------- |
-| `AZURE_DEFAULTS_LOCATION` | `swedencentral`        | Default Azure region (matches repo guidelines) |
-| `GH_TOKEN`                | `${localEnv:GH_TOKEN}` | GitHub PAT forwarded from host; enables `gh` CLI without interactive login |
+| Variable                  | Value                  | Purpose                                                                             |
+| ------------------------- | ---------------------- | ----------------------------------------------------------------------------------- |
+| `AZURE_DEFAULTS_LOCATION` | `swedencentral`        | Default Azure region (matches repo guidelines)                                      |
+| `GH_TOKEN`                | `${localEnv:GH_TOKEN}` | GitHub PAT set in VS Code User Settings; enables `gh` CLI without interactive login |
 
 ### Azure Credentials Mount
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,8 +46,9 @@
   "remoteEnv": {
     "AZURE_DEFAULTS_LOCATION": "swedencentral",
     // Pass GH_TOKEN from host → container. gh CLI uses it automatically, no `gh auth login` needed.
-    // Each user sets this once on their host: export GH_TOKEN=<pat> (Linux/macOS) or
-    // [System.Environment]::SetEnvironmentVariable('GH_TOKEN','<pat>','User') (Windows PowerShell).
+    // Each user sets this once in VS Code User Settings (Ctrl+,):
+    //   "terminal.integrated.env.linux": { "GH_TOKEN": "ghp_yourTokenHere" }
+    // This is the ONLY supported method — shell exports (.bashrc/.profile) do NOT propagate reliably.
     // Value is empty string if not set — gh CLI falls back to its normal auth flow.
     "GH_TOKEN": "${localEnv:GH_TOKEN}"
   },

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,7 @@ Agents read skills via: **"Read `.github/skills/{name}/SKILL.md`"** in their bod
 - For issues and pull requests, always prefer GitHub MCP tools over `gh` CLI.
 - Only use `gh` for operations that have no equivalent MCP write tool in the current environment.
 - In devcontainers, do not run `gh auth` commands unless the user explicitly asks for CLI authentication troubleshooting.
+- `GH_TOKEN` is set via VS Code User Settings (`terminal.integrated.env.linux`) — shell exports do not propagate reliably.
 
 ## Key Conventions
 

--- a/.github/skills/github-operations/SKILL.md
+++ b/.github/skills/github-operations/SKILL.md
@@ -28,6 +28,8 @@ Follow this protocol for every GitHub task:
 
 - Do not run `gh auth login` or `gh auth status` in devcontainer workflows
   unless the user explicitly asks for CLI auth troubleshooting.
+- `GH_TOKEN` must be set via VS Code User Settings (`terminal.integrated.env.linux`)
+  — shell exports (`.bashrc`, `.profile`) do NOT propagate reliably into devcontainers.
 - For PR/issue creation, rely on MCP tool authentication by default.
 - If MCP write tools are missing in the current environment,
   report the limitation explicitly and provide a no-auth fallback path

--- a/docs/dev-containers.md
+++ b/docs/dev-containers.md
@@ -101,8 +101,14 @@ First build takes 2-5 minutes. Subsequent opens are instant.
 ### Step 4: GitHub CLI Authentication (PAT)
 
 HTTPS-based `gh auth login` can fail inside devcontainers on some platforms (Windows, ARM, WSL 2).
-The recommended approach is a **Personal Access Token (PAT)** set as a host environment variable.
+The **only supported** approach is a **Personal Access Token (PAT)** set in **VS Code User Settings**.
 The container reads it automatically — no `gh auth login` required inside the container.
+
+> **Why not shell exports?** Setting `GH_TOKEN` in `~/.bashrc`, `~/.profile`, or PowerShell
+> environment variables does **not** propagate reliably into devcontainers. VS Code reads
+> `${localEnv:GH_TOKEN}` from its own process environment, which only inherits from the
+> specific shell session that launched it. The VS Code settings method is deterministic and
+> survives rebuilds, reboots, and IDE restarts.
 
 #### Create a Fine-Grained PAT
 
@@ -122,21 +128,24 @@ The container reads it automatically — no `gh auth login` required inside the 
 
 6. Copy the token (`github_pat_...`)
 
-#### Set it on your host machine (once per machine)
+#### Add to VS Code User Settings (once per machine)
 
-```bash
-# Linux / macOS / WSL 2 — add to ~/.bashrc, ~/.zshrc, or ~/.profile, then reload
-export GH_TOKEN=github_pat_your_token_here
+1. Open VS Code Settings: **Ctrl+,** (or **Cmd+,** on macOS)
+2. Click the **Open Settings (JSON)** icon (top-right)
+3. Add this entry (replace the placeholder with your actual token):
+
+```jsonc
+"terminal.integrated.env.linux": { "GH_TOKEN": "github_pat_your_token_here" }
 ```
 
-```powershell
-# Windows PowerShell — user-scoped, survives reboots
-[System.Environment]::SetEnvironmentVariable('GH_TOKEN', 'github_pat_your_token_here', 'User')
-```
+<!-- markdownlint-disable MD029 -->
 
-The devcontainer is already configured to forward `GH_TOKEN` from your host into the container
-(`"GH_TOKEN": "${localEnv:GH_TOKEN}"` in `devcontainer.json`). If the variable is not set,
-`gh` falls back to its normal interactive auth flow.
+4. Save the file
+5. Rebuild the devcontainer: **F1 → Dev Containers: Rebuild Container**
+<!-- markdownlint-enable MD029 -->
+
+The devcontainer forwards `GH_TOKEN` from VS Code's environment automatically
+(`"GH_TOKEN": "${localEnv:GH_TOKEN}"` in `devcontainer.json`).
 
 #### Verify inside the container
 
@@ -145,7 +154,7 @@ gh auth status
 # Expected: ✓ Logged in to github.com as <your-username> (token)
 ```
 
-> **Token rotation**: When your PAT expires, update the env var on each host machine and
+> **Token rotation**: When your PAT expires, update the value in VS Code User Settings and
 > rebuild the container (`F1 → Dev Containers: Rebuild Container`).
 
 ### Step 5: Verify Setup


### PR DESCRIPTION
## Summary

Documents VS Code User Settings (`terminal.integrated.env.linux`) as the **only supported** method for propagating `GH_TOKEN` into devcontainers. Removes shell export instructions which do not propagate reliably.

## Changes

- `.devcontainer/devcontainer.json`: comments updated
- `.devcontainer/README.md`: GH_TOKEN section rewritten; explains why shell exports fail
- `docs/dev-containers.md`: same rewrite for public-facing setup guide
- `.github/skills/github-operations/SKILL.md`: devcontainer rule reinforced
- `.github/copilot-instructions.md`: one-liner added for agent awareness