### PR TITLE
fix(docs): point users to Accelerator template repo, rename workshop to MicroHack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,11 @@ Specialized AI agents collaborate through a structured 7-step workflow:
 ## Setup Commands
 
 ```bash
-# Clone and open in dev container (all tools pre-installed)
-git clone https://github.com/jonathan-vella/azure-agentic-infraops.git
-cd azure-agentic-infraops
+# Create your own repo from the Accelerator template:
+#   https://github.com/jonathan-vella/azure-agentic-infraops-accelerator
+# Then clone YOUR repo and open in dev container
+git clone https://github.com/YOUR-USERNAME/my-infraops-project.git
+cd my-infraops-project
 code .
 # F1 → Dev Containers: Reopen in Container
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,10 @@ npm run lint:md:fix
 
 ### 1. Fork & Clone
 
+> **Note:** For **using** Agentic InfraOps, create your own repo from the
+> [Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
+> instead. The instructions below are for contributing back to this upstream project.
+
 ```bash
 git clone https://github.com/YOUR-USERNAME/azure-agentic-infraops.git
 cd azure-agentic-infraops

--- a/README.md
+++ b/README.md
@@ -171,18 +171,18 @@ sequenceDiagram
 > [!IMPORTANT]
 > **Prerequisites:** Docker Desktop (or Podman/Rancher), VS Code with Dev Containers, GitHub Copilot.
 
-```bash
-git clone https://github.com/jonathan-vella/azure-agentic-infraops.git
-cd azure-agentic-infraops
-code .
-```
-
-1. Press `F1` → **Dev Containers: Reopen in Container** _(first build: ~2-3 min, all tools pre-installed)_
-2. Enable the required VS Code setting:
+1. Go to the [**Accelerator template**](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator) → click **"Use this template"** → **"Create a new repository"**
+2. Clone **your new repo** and open in VS Code:
+   ```bash
+   git clone https://github.com/YOUR-USERNAME/my-infraops-project.git
+   code my-infraops-project
+   ```
+3. Press `F1` → **Dev Containers: Reopen in Container** _(first build: ~2-3 min, all tools pre-installed)_
+4. Enable the required VS Code setting:
    ```json
    { "chat.customAgentInSubagent.enabled": true }
    ```
-3. Press `Ctrl+Shift+I` → select **InfraOps Conductor** → describe your infrastructure
+5. Press `Ctrl+Shift+I` → select **InfraOps Conductor** → describe your infrastructure
 
 ```text
 Create a web app with Azure App Service, Key Vault, and SQL Database
@@ -263,17 +263,17 @@ Steps 1-3 and 7 are shared. Steps 4-6 have **Bicep** and **Terraform** variants.
 
 ## 🌐 Related Repositories
 
-### 🚀 [Accelerator Patterns](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
+### 🚀 [Accelerator Template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
 
-A curated collection of pre-built, production-ready Azure infrastructure patterns generated and
-validated by the Agentic InfraOps workflow. Use it as a starting point for common workload
-archetypes—each pattern ships with Bicep templates, agent artifacts, and deployment scripts.
+The **recommended starting point** for new users. This is a GitHub template repository —
+click "Use this template" to create your own repo with all agents, skills, dev container
+configuration, and deployment scripts ready to go. Clean commit history, no fork relationship.
 
-### 🎓 [Training Workshops](https://jonathan-vella.github.io/microhack-agentic-infraops/)
+### 🎯 [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/)
 
-Hands-on workshop material for teams and individuals learning the Agentic InfraOps workflow.
-Structured labs walk you through each of the 7 steps with guided exercises, sample prompts, and
-reference solutions—from first Conductor run to full deployment.
+A hands-on, guided challenge where you build Azure infrastructure end-to-end using AI agents
+— from requirements to deployment. Structured exercises walk you through each of the 7 steps
+with guided prompts and reference solutions.
 
 <img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png" width="100%" alt="divider">
 <div align="right"><a href="#readme-top"><b>⬆️ Back to Top</b></a></div>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -95,6 +95,12 @@ npm run lint:md:fix
 
 ### 1. Fork & Clone
 
+!!! note "Contributing to the upstream project"
+
+    For **using** Agentic InfraOps, create your own repo from the
+    [Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator).
+    The instructions below are for contributing back to this upstream project.
+
 ```bash
 git clone https://github.com/YOUR-USERNAME/azure-agentic-infraops.git
 cd azure-agentic-infraops

--- a/docs/dev-containers.md
+++ b/docs/dev-containers.md
@@ -91,10 +91,16 @@ Or install from Extensions (`Ctrl+Shift+X`) → search "Dev Containers".
 ### Step 3: Open in Dev Container
 
 ```bash
-git clone https://github.com/jonathan-vella/azure-agentic-infraops.git
-cd azure-agentic-infraops
+git clone https://github.com/YOUR-USERNAME/my-infraops-project.git
+cd my-infraops-project
 code .
 ```
+
+!!! info "Use the template repository"
+
+    Do not clone this upstream project directly. Create your own repo from the
+    [Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
+    first. See the [Quickstart](quickstart.md) for the full setup flow.
 
 Press `F1` → **Dev Containers: Reopen in Container**
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,6 +6,16 @@ Frequently asked questions about Agentic InfraOps.
 
 ## General
 
+??? question "How do I get started?"
+
+    Create your own repository from the
+    [Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
+    — click **"Use this template"** on GitHub, clone your new repo, and open it in the dev
+    container. See the [Quickstart](quickstart.md) for the step-by-step guide.
+
+    This upstream repository (`azure-agentic-infraops`) is the source project. The Accelerator
+    template is the recommended starting point for new users.
+
 ??? question "Is this project production-ready?"
 
     Agentic InfraOps is currently at **v0.10.0** (pre-1.0). It is suitable for
@@ -112,6 +122,13 @@ Frequently asked questions about Agentic InfraOps.
        which steps are complete, then continues from the next pending step.
 
     See the [Quickstart](quickstart.md) for the full getting-started flow.
+
+??? question "Is there a guided hands-on exercise?"
+
+    Yes — the [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/) is a
+    hands-on, guided challenge where you build Azure infrastructure end-to-end using AI agents,
+    from requirements to deployment. It includes structured exercises, guided prompts, and
+    reference solutions for each of the 7 workflow steps.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Framework and Azure Verified Modules.
 accelerate Azure infrastructure delivery with AI-assisted workflows.
 
 [Get Started](quickstart.md){ .md-button .md-button--primary }
-[View on GitHub](https://github.com/jonathan-vella/azure-agentic-infraops){ .md-button }
+[Use the Template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator){ .md-button }
 
 ---
 
@@ -31,7 +31,7 @@ accelerate Azure infrastructure delivery with AI-assisted workflows.
 
   ***
 
-  Set up your dev container and run your first agent workflow in 10 minutes.
+  Set up from the Accelerator template and run your first agent workflow in 10 minutes.
 
   [:octicons-arrow-right-24: Quickstart](quickstart.md)
 
@@ -119,3 +119,5 @@ See the [Changelog](CHANGELOG.md) for the full release history.
 - **Issues**: [GitHub Issues](https://github.com/jonathan-vella/azure-agentic-infraops/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/jonathan-vella/azure-agentic-infraops/discussions)
 - **Troubleshooting**: [Troubleshooting Guide](troubleshooting.md)
+- **MicroHack**: [Hands-on guided challenge](https://jonathan-vella.github.io/microhack-agentic-infraops/)
+  — build Azure infrastructure end-to-end using AI agents

--- a/docs/presenter/README.md
+++ b/docs/presenter/README.md
@@ -98,12 +98,16 @@ See [Objection Handling Guide](objection-handling.md) for complete responses wit
 <div align="right"><a href="#top"><b>⬆️ Back to Top</b></a></div>
 
 
-## 📋 Workshop Delivery
+## 📋 MicroHack Delivery
 
 ### Preparation Checklists
 
-- [Workshop Checklist](workshop-checklist.md) - Complete preparation guide for hands-on workshops
+- [MicroHack Checklist](workshop-checklist.md) - Complete preparation guide for hands-on sessions
 - [Pilot Success Checklist](pilot-success-checklist.md) - Customer pilot prerequisites
+
+🎯 **MicroHack site**: <https://jonathan-vella.github.io/microhack-agentic-infraops/> —
+a hands-on, guided challenge where participants build Azure infrastructure end-to-end
+using AI agents, from requirements to deployment.
 
 ### Interactive Materials
 
@@ -124,7 +128,7 @@ See [Objection Handling Guide](objection-handling.md) for complete responses wit
 | `pilot-success-checklist.md` | Customer pilot checklist      |
 | `roi-calculator.md`          | ROI calculation guide         |
 | `time-savings-evidence.md`   | Time savings methodology      |
-| `workshop-checklist.md`      | Workshop preparation          |
+| `workshop-checklist.md`      | MicroHack delivery preparation  |
 
 <img src="https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png" alt="section divider" width="100%">
 <div align="right"><a href="#top"><b>⬆️ Back to Top</b></a></div>

--- a/docs/presenter/workshop-checklist.md
+++ b/docs/presenter/workshop-checklist.md
@@ -1,13 +1,17 @@
 <a id="top"></a>
 
-# Workshop Delivery Checklist
+# MicroHack Delivery Checklist
 
 > **[Version](../../VERSION.md)** | [Back to Presenter Resources](README.md)
 >
-> A comprehensive checklist for trainers delivering Agentic InfraOps workshops.
+> A comprehensive checklist for trainers delivering Agentic InfraOps MicroHack sessions.
 > Use this before, during, and after your sessions to ensure smooth delivery.
+>
+> 🎯 **MicroHack site**: <https://jonathan-vella.github.io/microhack-agentic-infraops/>
+> — A hands-on, guided challenge where participants build Azure infrastructure
+> end-to-end using AI agents, from requirements to deployment.
 
-## 🗓️ Pre-Workshop (1-2 Days Before)
+## 📅️ Pre-Session (1-2 Days Before)
 
 ### Environment Preparation
 
@@ -125,7 +129,7 @@
 <div align="right"><a href="#top"><b>⬆️ Back to Top</b></a></div>
 
 
-## 🎯 During Workshop
+## 🎯 During Session
 
 ### Opening (First 10 Minutes)
 
@@ -185,7 +189,7 @@
 <div align="right"><a href="#top"><b>⬆️ Back to Top</b></a></div>
 
 
-## 📊 Post-Workshop
+## 📊 Post-Session
 
 ### Immediate (Within 30 Minutes)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,6 +8,14 @@
 
 Get running in 10 minutes.
 
+!!! info "Template repository"
+
+    You do **not** clone this repository directly. Instead, you create your own
+    repository from the
+    [Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator),
+    which gives you a clean starting point with all agents, skills, and dev container
+    configuration ready to go.
+
 ## :material-clipboard-check-outline: Prerequisites
 
 !!! info "What you need before starting"
@@ -23,14 +31,34 @@ Get running in 10 minutes.
 | Docker Desktop         | [Download](https://www.docker.com/products/docker-desktop/) |
 | Azure subscription     | Optional for learning                                       |
 
-## :material-content-copy: Step 1: Clone and Open
+## :material-source-repository: Step 1: Create Your Repository from the Template
+
+1. Go to the
+   [Accelerator template repository](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
+2. Click the green **"Use this template"** button → **"Create a new repository"**
+3. Choose an owner and repository name (e.g. `my-infraops-project`)
+4. Select **Public** or **Private** visibility
+5. Click **Create repository**
+
+!!! tip "What is a template repository?"
+
+    A [GitHub template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)
+    creates a brand-new repository with the same directory structure and files — but
+    with a clean commit history and no fork relationship. Your repo is entirely yours.
+
+## :material-content-copy: Step 2: Clone and Open
+
+Clone **your new repository** (not this upstream project):
 
 ```bash
-git clone https://github.com/jonathan-vella/azure-agentic-infraops.git
-code azure-agentic-infraops
+git clone https://github.com/YOUR-USERNAME/my-infraops-project.git # (1)!
+code my-infraops-project
 ```
 
-## :material-docker: Step 2: Open in Dev Container
+1. :material-swap-horizontal: Replace `YOUR-USERNAME/my-infraops-project` with your actual
+   GitHub username and the repository name you chose in Step 1.
+
+## :material-docker: Step 3: Open in Dev Container
 
 1. Press `F1` (or `Ctrl+Shift+P`)
 2. Type: `Dev Containers: Reopen in Container`
@@ -45,7 +73,7 @@ The Dev Container installs all tools automatically:
 - Go (Terraform MCP server)
 - 25+ VS Code extensions
 
-## :material-check-circle-outline: Step 3: Verify Setup
+## :material-check-circle-outline: Step 4: Verify Setup
 
 !!! tip "Verify all tools installed correctly"
 
@@ -55,9 +83,10 @@ The Dev Container installs all tools automatically:
 az --version && bicep --version && terraform --version && pwsh --version # (1)!
 ```
 
-1. :material-check-all: All four CLIs should print version numbers. If any fail, reopen the dev container.
+1. :material-check-all: All four CLIs should print version numbers. If any fail, reopen
+   the dev container.
 
-## :material-toggle-switch-outline: Step 4: Enable Subagent Orchestration
+## :material-toggle-switch-outline: Step 5: Enable Subagent Orchestration
 
 !!! warning "Required"
 
@@ -83,7 +112,7 @@ take precedence for experimental features like subagent invocation.
 2. Type: `Preferences: Open User Settings (JSON)`
 3. Confirm the setting is present
 
-## :material-play-circle-outline: Step 5: Start the Conductor
+## :material-play-circle-outline: Step 6: Start the Conductor
 
 ### Option A: InfraOps Conductor (Recommended)
 
@@ -113,7 +142,7 @@ Invoke agents directly for specific tasks:
 2. Select the specific agent (e.g., `requirements`)
 3. Enter your prompt
 
-## :material-chart-timeline-variant: Step 6: Follow the Workflow
+## :material-chart-timeline-variant: Step 7: Follow the Workflow
 
 The agents work in sequence with handoffs. Steps 1-3 and 7 are shared;
 steps 4-6 route to **Bicep** or **Terraform** agents based on your `iac_tool` selection.
@@ -177,14 +206,16 @@ infra/terraform/my-webapp/
 
 ## :material-arrow-right-circle-outline: Next Steps
 
-| Goal                           | Resource                                 |
-| ------------------------------ | ---------------------------------------- |
-| Understand the full workflow   | [workflow.md](workflow.md)               |
-| Try a complete workflow        | [Prompt Guide](prompt-guide/index.md)    |
-| Generate architecture diagrams | Use `azure-diagrams` skill               |
-| Create documentation           | Use `azure-artifacts` skill              |
-| Explore Terraform patterns     | Use `terraform-patterns` skill           |
-| Troubleshoot issues            | [troubleshooting.md](troubleshooting.md) |
+| Goal                            | Resource                                                                                                                     |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Understand the full workflow    | [workflow.md](workflow.md)                                                                                                   |
+| Try a guided hands-on challenge | [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/)                                                   |
+| Try a complete workflow         | [Prompt Guide](prompt-guide/index.md)                                                                                       |
+| Generate architecture diagrams  | Use `azure-diagrams` skill                                                                                                   |
+| Create documentation            | Use `azure-artifacts` skill                                                                                                  |
+| Explore Terraform patterns      | Use `terraform-patterns` skill                                                                                               |
+| Troubleshoot issues             | [troubleshooting.md](troubleshooting.md)                                                                                     |
+| Contribute to the upstream repo | [azure-agentic-infraops](https://github.com/jonathan-vella/azure-agentic-infraops)                                           |
 
 ## :material-lightning-bolt: Quick Reference
 


### PR DESCRIPTION
## Summary

Two related documentation changes:

### 1. Template Repository Flow

Users should no longer clone this upstream repo directly. Instead, they create their own repo from the [Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator).

**Changes:**
- **Quickstart** — completely rewritten: new Step 1 ("Create Your Repository from the Template") with "Use this template" instructions, template repo explanation admonition, step numbers adjusted (now 7 steps)
- **Home page** — second CTA button changed from "View on GitHub" to "Use the Template" linking to accelerator
- **README Quick Start** — rewritten to start with "Use this template" flow
- **AGENTS.md** — setup commands updated with template comment and `YOUR-USERNAME` placeholder
- **dev-containers.md** — clone command updated to `YOUR-USERNAME` with info admonition about template
- **CONTRIBUTING.md** (both root and docs/) — added note distinguishing "using" (template) vs "contributing" (fork upstream)
- **FAQ** — new entry: "How do I get started?" explaining the two-repo model

### 2. Workshop → MicroHack

All references to "workshop" / "Training Workshops" updated to "MicroHack":

- **README** — Related Repositories section: renamed to "MicroHack" with updated description
- **presenter/workshop-checklist.md** — renamed headings (Pre-Workshop → Pre-Session, During Workshop → During Session, Post-Workshop → Post-Session), added MicroHack site link
- **presenter/README.md** — section renamed, MicroHack link and description added
- **FAQ** — new entry: "Is there a guided hands-on exercise?" with MicroHack link
- **Quickstart Next Steps** — added MicroHack row
- **Home page Getting Help** — added MicroHack link

**MicroHack**: A hands-on, guided challenge where you build Azure infrastructure end-to-end using AI agents — from requirements to deployment.

## Validation
- `mkdocs build --strict` — 0 warnings
- `npm run lint:md` — 0 errors
- All hooks passed (link-check, markdown-lint, commitlint, deprecated-refs, json-syntax, version-sync)

## Files Changed (10)
`AGENTS.md`, `CONTRIBUTING.md`, `README.md`, `docs/CONTRIBUTING.md`, `docs/dev-containers.md`, `docs/faq.md`, `docs/index.md`, `docs/presenter/README.md`, `docs/presenter/workshop-checklist.md`, `docs/quickstart.md`