### PR TITLE
ci: permanently fix validate:all CI failures

### DIFF
--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -66,13 +66,14 @@ concurrency:
 
 | Workflow                        | Purpose                               | Trigger                  |
 | ------------------------------- | ------------------------------------- | ------------------------ |
-| `lint.yml`                      | Markdown lint + code quality          | PR + push to main        |
-| `agent-validation.yml`          | Agent/skill/VS Code config validation | Changes to agents/skills |
-| `policy-compliance-check.yml`   | Governance guardrail validation       | PR + push to main        |
-| `docs.yml`                      | MkDocs site deployment to Pages       | Push to main (docs/)     |
-| `docs-freshness.yml`            | Doc count/reference drift detection   | Weekly + manual dispatch |
-| `avm-version-check.yml`         | Azure Verified Module version checks  | Weekly + manual dispatch |
-| `azure-deprecation-tracker.yml` | Azure deprecation monitoring          | Weekly + manual dispatch |
+| `lint.yml`                      | Markdown lint + code quality          | PR + push to main                 |
+| `agent-validation.yml`          | Agent/skill/VS Code config validation | Changes to agents/skills          |
+| `policy-compliance-check.yml`   | Governance guardrail validation       | Changes to agents/skills          |
+| `link-check.yml`                | Broken link detection in docs/        | Changes to docs/ + weekly         |
+| `docs.yml`                      | MkDocs site deployment to Pages       | Push to main (docs/)              |
+| `docs-freshness.yml`            | Doc count/reference drift detection   | Weekly + manual dispatch          |
+| `avm-version-check.yml`         | Azure Verified Module version checks  | Weekly + manual dispatch          |
+| `azure-deprecation-tracker.yml` | Azure deprecation monitoring          | Weekly + manual dispatch          |
 
 ## Validation Scripts
 

--- a/.github/skills/copilot-customization/SKILL.md
+++ b/.github/skills/copilot-customization/SKILL.md
@@ -97,7 +97,7 @@ These instruction files auto-load for matching files. This skill references but 
 | `agent-research-first.instructions.md` | Agents, output, skills          | Research-before-implementation mandate   |
 | `context-optimization.instructions.md` | Agents, skills, instructions    | Context budget, hand-off rules           |
 
-## References
+## Reference Index
 
 Load only the reference file relevant to your current task:
 

--- a/.github/skills/copilot-customization/references/agent-plugins.md
+++ b/.github/skills/copilot-customization/references/agent-plugins.md
@@ -1,3 +1,4 @@
+<!-- ref:agent-plugins-v1 -->
 # Agent Plugins Reference (Preview)
 
 > Source: https://code.visualstudio.com/docs/copilot/customization/agent-plugins

--- a/.github/skills/copilot-customization/references/agent-skills.md
+++ b/.github/skills/copilot-customization/references/agent-skills.md
@@ -1,3 +1,4 @@
+<!-- ref:agent-skills-v1 -->
 # Agent Skills Reference
 
 > Source: https://code.visualstudio.com/docs/copilot/customization/agent-skills

--- a/.github/skills/copilot-customization/references/custom-agents.md
+++ b/.github/skills/copilot-customization/references/custom-agents.md
@@ -1,3 +1,4 @@
+<!-- ref:custom-agents-v1 -->
 # Custom Agents Reference
 
 > Source: https://code.visualstudio.com/docs/copilot/customization/custom-agents

--- a/.github/skills/copilot-customization/references/custom-instructions.md
+++ b/.github/skills/copilot-customization/references/custom-instructions.md
@@ -1,3 +1,4 @@
+<!-- ref:custom-instructions-v1 -->
 # Custom Instructions Reference
 
 > Source: https://code.visualstudio.com/docs/copilot/customization/custom-instructions

--- a/.github/skills/copilot-customization/references/hooks.md
+++ b/.github/skills/copilot-customization/references/hooks.md
@@ -1,3 +1,4 @@
+<!-- ref:hooks-v1 -->
 # Hooks Reference (Preview)
 
 > Source: https://code.visualstudio.com/docs/copilot/customization/hooks

--- a/.github/skills/copilot-customization/references/mcp-servers.md
+++ b/.github/skills/copilot-customization/references/mcp-servers.md
@@ -1,3 +1,4 @@
+<!-- ref:mcp-servers-v1 -->
 # MCP Servers Reference
 
 > Source: https://code.visualstudio.com/docs/copilot/customization/mcp-servers

--- a/.github/skills/copilot-customization/references/prompt-files.md
+++ b/.github/skills/copilot-customization/references/prompt-files.md
@@ -1,3 +1,4 @@
+<!-- ref:prompt-files-v1 -->
 # Prompt Files Reference
 
 > Source: https://code.visualstudio.com/docs/copilot/customization/prompt-files

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,48 @@
+# Link Check Workflow
+# Validates all hyperlinks in docs/ are reachable
+# Separated from validate:all to isolate network-dependent checks from code quality gates
+
+name: link-check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".markdown-link-check.json"
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".markdown-link-check.json"
+  schedule:
+    # Run weekly on Monday at 07:00 UTC (staggered from other weekly workflows)
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  link-check:
+    name: Check docs links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check links in docs/
+        run: npm run lint:links:docs

--- a/.github/workflows/policy-compliance-check.yml
+++ b/.github/workflows/policy-compliance-check.yml
@@ -44,21 +44,8 @@ jobs:
           node-version: "22"
           cache: "npm"
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "latest"
-
-      - name: Install Python linting tools
-        run: pip install ruff
-
       - name: Install dependencies
         run: npm ci
 
-      - name: Run all existing validations
-        run: npm run validate:all
+      - name: Run node validations
+        run: npm run validate:_node

--- a/mcp/azure-pricing-mcp/tests/test_client_http.py
+++ b/mcp/azure-pricing-mcp/tests/test_client_http.py
@@ -1,0 +1,90 @@
+"""HTTP-level tests for AzurePricingClient using aioresponses.
+
+Tests Retry-After header parsing, per-request timeout, and connection pooling.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+
+from azure_pricing_mcp.client import AzurePricingClient
+from azure_pricing_mcp.config import AZURE_PRICING_BASE_URL
+
+
+@pytest.fixture
+def mock_aio():
+    with aioresponses() as m:
+        yield m
+
+
+class TestRetryAfterHeader:
+    @pytest.mark.asyncio
+    async def test_respects_retry_after_header(self, mock_aio):
+        """When the API returns 429 with Retry-After, use that value."""
+        mock_aio.get(
+            AZURE_PRICING_BASE_URL,
+            status=429,
+            headers={"Retry-After": "1"},
+        )
+        mock_aio.get(
+            AZURE_PRICING_BASE_URL,
+            status=200,
+            payload={"Items": [], "Count": 0},
+        )
+
+        with patch("azure_pricing_mcp.client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            async with AzurePricingClient() as client:
+                result = await client.make_request(max_retries=1)
+                assert result["Count"] == 0
+                mock_sleep.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_without_retry_after(self, mock_aio):
+        """Without Retry-After header, fall back to exponential backoff."""
+        mock_aio.get(AZURE_PRICING_BASE_URL, status=429)
+        mock_aio.get(
+            AZURE_PRICING_BASE_URL,
+            status=200,
+            payload={"Items": [{"skuName": "test"}], "Count": 1},
+        )
+
+        with patch("azure_pricing_mcp.client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            async with AzurePricingClient() as client:
+                result = await client.make_request(max_retries=1)
+                assert result["Count"] == 1
+                # Default backoff: RATE_LIMIT_RETRY_BASE_WAIT * (attempt + 1) = 5 * 1 = 5
+                mock_sleep.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_caps_retry_after_at_60s(self, mock_aio):
+        """Retry-After values over 60s should be capped at 60."""
+        mock_aio.get(
+            AZURE_PRICING_BASE_URL,
+            status=429,
+            headers={"Retry-After": "999"},
+        )
+        mock_aio.get(
+            AZURE_PRICING_BASE_URL,
+            status=200,
+            payload={"Items": [], "Count": 0},
+        )
+
+        with patch("azure_pricing_mcp.client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            async with AzurePricingClient() as client:
+                result = await client.make_request(max_retries=1)
+                assert result["Count"] == 0
+                mock_sleep.assert_awaited_once_with(60)
+
+
+class TestConnectionPooling:
+    @pytest.mark.asyncio
+    async def test_connector_has_pool_limits(self):
+        """The client should create a TCPConnector with pool limits."""
+        async with AzurePricingClient() as client:
+            assert client.session is not None
+            connector = client.session.connector
+            assert isinstance(connector, aiohttp.TCPConnector)
+            assert connector.limit == 10
+            assert connector.limit_per_host == 5

--- a/mcp/azure-pricing-mcp/tests/test_optimizations.py
+++ b/mcp/azure-pricing-mcp/tests/test_optimizations.py
@@ -1,0 +1,323 @@
+"""Tests for optimization changes: field projection, compact handlers, circuit breaker."""
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from azure_pricing_mcp.formatters import format_compact
+
+
+class TestFieldProjection:
+    """Tests for compact format field projection."""
+
+    def test_projects_pricing_items(self):
+        """Items in compact mode should only contain essential fields."""
+        result = {
+            "items": [
+                {
+                    "serviceName": "Virtual Machines",
+                    "productName": "Virtual Machines D Series",
+                    "skuName": "D2s v3",
+                    "armRegionName": "eastus",
+                    "location": "US East",
+                    "retailPrice": 0.096,
+                    "unitOfMeasure": "1 Hour",
+                    "type": "Consumption",
+                    "meterName": "D2s v3",
+                    "effectiveStartDate": "2024-01-01",
+                    "savingsPlan": [{"term": "1 Year", "retailPrice": 0.062}],
+                    "isPrimaryMeterRegion": True,
+                }
+            ],
+            "count": 1,
+        }
+        output = json.loads(format_compact(result))
+        item = output["items"][0]
+        assert set(item.keys()) == {"serviceName", "skuName", "armRegionName", "retailPrice", "unitOfMeasure", "type"}
+        assert item["retailPrice"] == 0.096
+        assert "productName" not in item
+        assert "savingsPlan" not in item
+        assert "meterName" not in item
+
+    def test_projects_recommendations(self):
+        """Region recommendations should be projected."""
+        result = {
+            "recommendations": [
+                {
+                    "region": "eastus",
+                    "location": "US East",
+                    "retail_price": 0.096,
+                    "spot_price": 0.02,
+                    "savings_vs_most_expensive": 15.0,
+                    "unit_of_measure": "1 Hour",
+                    "original_price": 0.106,
+                }
+            ],
+            "service_name": "Virtual Machines",
+        }
+        output = json.loads(format_compact(result))
+        rec = output["recommendations"][0]
+        assert "region" in rec
+        assert "retail_price" in rec
+        assert "spot_price" in rec
+        assert "savings_vs_most_expensive" in rec
+        assert "unit_of_measure" not in rec
+        assert "original_price" not in rec
+
+    def test_projects_line_items(self):
+        """Bulk estimate line items should be projected."""
+        result = {
+            "line_items": [
+                {
+                    "service_name": "Virtual Machines",
+                    "sku_name": "D2s v3",
+                    "region": "eastus",
+                    "quantity": 2,
+                    "monthly_cost": 140.16,
+                    "yearly_cost": 1681.92,
+                    "indices": [0],
+                    "unit_rate": 0.096,
+                    "pricing_model": "per-hour",
+                }
+            ],
+            "totals": {"monthly": 140.16, "yearly": 1681.92},
+        }
+        output = json.loads(format_compact(result))
+        item = output["line_items"][0]
+        assert "service_name" in item
+        assert "monthly_cost" in item
+        assert "indices" not in item
+        assert "unit_rate" not in item
+
+    def test_projects_ri_items(self):
+        """RI items should be projected."""
+        result = {
+            "ri_items": [
+                {
+                    "skuName": "D2s v3",
+                    "armRegionName": "eastus",
+                    "retailPrice": 0.062,
+                    "unitOfMeasure": "1 Hour",
+                    "reservationTerm": "1 Year",
+                    "productName": "Virtual Machines D Series",
+                    "meterName": "D2s v3",
+                }
+            ],
+            "count": 1,
+        }
+        output = json.loads(format_compact(result))
+        item = output["ri_items"][0]
+        assert "reservationTerm" in item
+        assert "productName" not in item
+
+    def test_projects_comparison(self):
+        """RI comparison should be projected."""
+        result = {
+            "comparison": [
+                {
+                    "sku": "D2s v3",
+                    "region": "eastus",
+                    "term": "1 Year",
+                    "savings_percentage": 35.0,
+                    "ri_hourly": 0.062,
+                    "od_hourly": 0.096,
+                    "break_even_months": 7,
+                    "annual_savings": 298,
+                    "ri_yearly": 543.12,
+                }
+            ],
+        }
+        output = json.loads(format_compact(result))
+        comp = output["comparison"][0]
+        assert "savings_percentage" in comp
+        assert "ri_yearly" not in comp
+
+    def test_no_indent_in_compact(self):
+        """Compact output should not use indentation."""
+        result = {"count": 5, "items": []}
+        output = format_compact(result)
+        assert "\n" not in output
+
+    def test_non_dict_items_passed_through(self):
+        """Non-dict items in a list should pass through unchanged."""
+        result = {"items": [1, 2, 3]}
+        output = json.loads(format_compact(result))
+        assert output["items"] == [1, 2, 3]
+
+    def test_preserves_pricing_model(self):
+        """pricing_model and usage_assumptions should NOT be stripped."""
+        result = {
+            "pricing_model": "per-hour",
+            "usage_assumptions": {"hours_per_month": 730},
+            "count": 1,
+        }
+        output = json.loads(format_compact(result))
+        assert output["pricing_model"] == "per-hour"
+        assert output["usage_assumptions"]["hours_per_month"] == 730
+
+
+class TestHandlerCompactSupport:
+    """Tests for handlers that now support compact output."""
+
+    @pytest.mark.asyncio
+    async def test_ri_pricing_compact(self):
+        """_do_ri_pricing should return compact JSON when output_format=compact."""
+        from azure_pricing_mcp.handlers import ToolHandlers
+
+        mock_pricing = AsyncMock()
+        mock_pricing.get_ri_pricing.return_value = {
+            "ri_items": [{"skuName": "D2s v3", "armRegionName": "eastus", "retailPrice": 0.062,
+                          "unitOfMeasure": "1 Hour", "reservationTerm": "1 Year", "productName": "VM"}],
+            "count": 1,
+            "currency": "USD",
+        }
+
+        handlers = ToolHandlers(mock_pricing, AsyncMock())
+        result = await handlers._do_ri_pricing({"service_name": "Virtual Machines", "output_format": "compact"})
+        output = json.loads(result[0].text)
+        assert "ri_items" in output
+        item = output["ri_items"][0]
+        assert "productName" not in item
+
+    @pytest.mark.asyncio
+    async def test_discover_skus_compact(self):
+        """_do_discover_skus should return compact JSON."""
+        from azure_pricing_mcp.handlers import ToolHandlers
+
+        mock_sku = AsyncMock()
+        mock_sku.discover_skus.return_value = {
+            "skus": [{"name": "D2s v3", "price": 0.096}],
+            "total_skus": 1,
+            "service_name": "Virtual Machines",
+        }
+
+        handlers = ToolHandlers(AsyncMock(), mock_sku)
+        result = await handlers._do_discover_skus({"service_name": "Virtual Machines", "output_format": "compact"})
+        output = json.loads(result[0].text)
+        assert output["total_skus"] == 1
+
+    @pytest.mark.asyncio
+    async def test_sku_discovery_compact(self):
+        """_do_sku_discovery should return compact JSON."""
+        from azure_pricing_mcp.handlers import ToolHandlers
+
+        mock_sku = AsyncMock()
+        mock_sku.discover_service_skus.return_value = {
+            "service_found": "Virtual Machines",
+            "original_search": "vm",
+            "skus": {},
+            "total_skus": 0,
+        }
+
+        handlers = ToolHandlers(AsyncMock(), mock_sku)
+        result = await handlers._do_sku_discovery({"service_hint": "vm", "output_format": "compact"})
+        output = json.loads(result[0].text)
+        assert output["service_found"] == "Virtual Machines"
+
+
+class TestBulkEstimateDiscountFix:
+    """Test that _do_bulk_estimate now attaches discount metadata."""
+
+    @pytest.mark.asyncio
+    async def test_attaches_discount_metadata(self):
+        from azure_pricing_mcp.handlers import ToolHandlers
+
+        mock_pricing = AsyncMock()
+        mock_bulk = AsyncMock()
+        mock_bulk.bulk_estimate.return_value = {
+            "line_items": [],
+            "errors": [],
+            "totals": {"monthly": 0, "yearly": 0},
+            "currency": "USD",
+            "resource_count": 0,
+            "successful": 0,
+            "failed": 0,
+        }
+
+        handlers = ToolHandlers(mock_pricing, AsyncMock(), bulk_service=mock_bulk)
+        result = await handlers._do_bulk_estimate({
+            "resources": [],
+            "output_format": "verbose",
+            "discount_percentage": 10,
+        })
+        # The handler should have called _attach_discount_metadata on the result
+        # In verbose mode, the text output should be generated from bulk formatter
+        assert len(result) == 1
+
+
+class TestCircuitBreaker:
+    """Tests for retirement service circuit breaker."""
+
+    @pytest.mark.asyncio
+    async def test_circuit_opens_after_consecutive_failures(self):
+        from azure_pricing_mcp.services.retirement import RetirementService
+
+        mock_client = AsyncMock()
+        mock_client.session = True  # Simulate active session
+        mock_client.fetch_text = AsyncMock(side_effect=Exception("GitHub down"))
+
+        service = RetirementService(mock_client)
+
+        # First call: failure 1 → still returns fallback
+        data1 = await service.get_retirement_data()
+        assert data1 is not None
+        assert service._consecutive_failures == 1
+        assert service._circuit_open_until is None
+
+        # Expire cache to force re-fetch
+        service._cache_time = datetime.now() - timedelta(hours=25)
+
+        # Second call: failure 2 → circuit opens
+        data2 = await service.get_retirement_data()
+        assert data2 is not None
+        assert service._consecutive_failures == 2
+        assert service._circuit_open_until is not None
+
+        # Third call: circuit is open → returns fallback without fetching
+        service._cache = None
+        service._cache_time = None
+        data3 = await service.get_retirement_data()
+        assert data3 is not None
+        # fetch_text was called twice (for failures), not a third time
+        # Each _fetch_retirement_data calls fetch_text twice (gather), so 4 total
+        assert mock_client.fetch_text.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_circuit_resets_on_success(self):
+        from azure_pricing_mcp.services.retirement import RetirementService
+
+        mock_client = AsyncMock()
+        mock_client.session = True
+
+        # Return valid markdown that parses to retirement data
+        retired_md = "| Series | Status | Replacement | Date |\n|---|---|---|---|\n| Dv2 | retirement announced | Dv5 | 2028-05-01 |"
+        mock_client.fetch_text = AsyncMock(return_value=retired_md)
+
+        service = RetirementService(mock_client)
+        service._consecutive_failures = 1  # Simulate prior failure
+
+        data = await service.get_retirement_data()
+        assert data is not None
+        assert service._consecutive_failures == 0
+
+
+class TestToolDefinitions:
+    """Verify trimmed tool definitions are valid."""
+
+    def test_all_8_tools_have_compact_default(self):
+        from azure_pricing_mcp.tools import get_tool_definitions
+
+        tools = get_tool_definitions()
+        compact_tools = [
+            t for t in tools
+            if t.inputSchema.get("properties", {}).get("output_format", {}).get("default") == "compact"
+        ]
+        assert len(compact_tools) == 8
+
+    def test_total_tool_count(self):
+        from azure_pricing_mcp.tools import get_tool_definitions
+
+        tools = get_tool_definitions()
+        assert len(tools) == 13

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "validate:skill-affinity": "node scripts/validate-skill-affinity.mjs",
     "validate:docs-sync": "node scripts/validate-docs-sync.mjs",
     "validate:_node": "run-p lint:artifact-templates lint:h2-sync lint:version-sync lint:deprecated-refs lint:mcp-config lint:agent-frontmatter lint:skills-format lint:instruction-frontmatter lint:governance-refs validate:instruction-refs validate:session-state validate:session-lock validate:workflow-graph validate:agent-registry validate:skill-affinity lint:json lint:skill-size lint:agent-body-size lint:glob-audit lint:skill-references lint:orphaned-content lint:docs-freshness",
-    "validate:_external": "run-p lint:md lint:links:docs lint:python lint:terraform-fmt validate:terraform",
+    "validate:_external": "run-p lint:md lint:python lint:terraform-fmt validate:terraform",
     "validate:all": "run-p --continue-on-error validate:_node validate:_external && echo '✅ All validations passed'"
   },
   "devDependencies": {

--- a/scripts/check-docs-freshness.mjs
+++ b/scripts/check-docs-freshness.mjs
@@ -126,7 +126,11 @@ async function checkProhibitedRefs(cachedDocsMdFiles) {
   const singleFiles = [join(ROOT, ".github", "copilot-instructions.md")];
 
   // Reuse cached docs MD files, only scan instructions dir fresh
-  const mdFiles = [...cachedDocsMdFiles];
+  // Exclude CHANGELOG files — they are historical records that may legitimately
+  // reference paths that have since been removed or restructured.
+  const mdFiles = [...cachedDocsMdFiles].filter(
+    (f) => !relative(ROOT, f).toLowerCase().includes("changelog"),
+  );
   for (const dir of scanPaths) {
     mdFiles.push(...(await collectMdFiles(dir, [])));
   }


### PR DESCRIPTION
## Problem

`validate:all` has been failing on every CI run on `main` and all branches for weeks. Three root causes identified and fixed:

---

### Root Cause 1: `lint:links:docs` in `validate:all`

`lint:links:docs` makes external HTTP requests and was part of `validate:_external`, which is included in `validate:all`. External link checks are inherently unreliable in CI (rate limiting, transient network failures on GitHub-hosted runners).

**Fix:** Remove `lint:links:docs` from `validate:_external` in `package.json`. Create a dedicated `link-check.yml` workflow that runs link checking on `docs/` path changes and weekly — properly isolated from code quality gates.

### Root Cause 2: `lint:docs-freshness` HIGH + LOW/MEDIUM findings

- **HIGH** (exit 1): `docs/CHANGELOG.md` referenced `docs/guides/` paths — legitimate historical changelog entries, not stale references
- **MEDIUM**: `copilot-customization/SKILL.md` had `## References` instead of `## Reference Index`

**Fix:** Exclude CHANGELOG files from the prohibited-refs check (historical records). Add canary markers to all 7 reference files. Rename section heading to match validator expectation.

### Root Cause 3: `lint:python` ruff errors

7 auto-fixable issues in newly added test files (`test_client_http.py`, `test_optimizations.py`): unused imports (`F401`) and unsorted import blocks (`I001`).

**Fix:** Auto-fixed with `ruff check --fix`.

---

### Bonus: `policy-compliance-check.yml` over-provisioned

The policy-compliance workflow was running `validate:all` (which includes Python lint, Terraform validate, and link checks) but only needs Node.js validators for governance compliance checks.

**Fix:** Switch to `validate:_node` only. Remove Python, Terraform, and ruff setup steps.

---

## Validation

```
npm run validate:all → ✅ All validations passed (EXIT: 0)
```
All pre-commit and pre-push hooks passed.