### PR TITLE
fix(devcontainer): upgrade pip in MCP venv before package installs

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -165,6 +165,8 @@ if [ -d "$MCP_DIR" ]; then
         python3 -m venv "$MCP_DIR/.venv"
     fi
 
+    "$MCP_DIR/.venv/bin/pip" install --quiet --upgrade pip 2>&1 | tail -1 || true
+
     cd "$MCP_DIR"
     "$MCP_DIR/.venv/bin/pip" install --quiet -e . 2>&1 | tail -1 || true
     cd - > /dev/null

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -23,6 +23,7 @@ fi
 # ─── Azure Pricing MCP ───────────────────────────────────────────────────────
 MCP_DIR="${WORKSPACE_FOLDER:-$PWD}/mcp/azure-pricing-mcp"
 if [ -f "$MCP_DIR/.venv/bin/pip" ]; then
+    "$MCP_DIR/.venv/bin/pip" install --quiet --upgrade pip 2>/dev/null || true
     printf "    azure-pricing-mcp     "
     "$MCP_DIR/.venv/bin/pip" install --quiet -e "$MCP_DIR" \
         && printf "✅ updated\n" \


### PR DESCRIPTION
## Summary

Suppress `[notice]` pip upgrade warnings that appeared on every container create and start.

## Changes

- **`post-create.sh` (Step 7)**: Added `pip install --upgrade pip` in the MCP venv right after venv creation, before the editable install.
- **`post-start.sh`**: Added `pip install --upgrade pip` before the editable install, so the notice is never shown on container restart.

## Root Cause

The bundled pip inside the freshly-created venv was older than the latest release. Running `pip install -e .` without upgrading pip first caused pip itself to print the upgrade notice to stdout, polluting the container setup log.