### PR TITLE
docs: accuracy fixes, Core Concepts rename, Codename, resources section

### DIFF
--- a/.github/skills/docs-writer/references/doc-standards.md
+++ b/.github/skills/docs-writer/references/doc-standards.md
@@ -150,9 +150,9 @@ When `VERSION.md` is updated, check these files for version references:
 
 ## Emoji Conventions in Agent/Skill Tables
 
-Personas use consistent emoji in `docs/README.md`:
+Codenames use consistent emoji in `docs/README.md`:
 
-| Persona    | Emoji | Agent              |
+| Codename   | Emoji | Agent              |
 | ---------- | ----- | ------------------ |
 | Maestro    | 🎼    | InfraOps Conductor |
 | Scribe     | 📜    | Requirements       |
@@ -163,4 +163,4 @@ Personas use consistent emoji in `docs/README.md`:
 | Envoy      | 🚀    | Deploy             |
 | Sentinel   | 🔍    | Diagnose           |
 
-When adding a new agent, choose a unique emoji + persona name.
+When adding a new agent, choose a unique emoji + codename.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,8 +28,11 @@ Frequently asked questions about Agentic InfraOps.
 ??? question "What AI models does this require?"
 
     The project is built for **GitHub Copilot** in VS Code. Agents specify their
-    preferred model in their frontmatter — most use Claude Opus 4.6 or GPT-5.3-Codex.
-    The Conductor and review-heavy agents perform best with Claude Opus 4.6.
+    preferred model in their frontmatter — most use the latest Claude Opus or
+    GPT Codex models. The Conductor and review-heavy agents perform best with
+    the latest Claude Opus model.
+
+    Model versions evolve — check agent frontmatter for current selections.
 
     You need an active **GitHub Copilot** license (Individual, Business, or Enterprise).
 

--- a/docs/how-it-works/agents.md
+++ b/docs/how-it-works/agents.md
@@ -13,7 +13,7 @@ Every agent definition follows a standard structure:
 ---
 name: 06b-Bicep CodeGen
 description: Expert Azure Bicep IaC specialist...
-model: ["Claude Opus 4.6"] # (1)!
+model: ["Claude Opus (latest)"] # (1)!
 tools: [list of allowed tools] # (2)!
 handoffs:
   - label: "Step 6: Deploy"
@@ -34,7 +34,26 @@ handoffs:
 The frontmatter is machine-readable metadata. The body is the agent's operating manual,
 loaded into the system prompt when the agent is invoked.
 
-## :material-account-supervisor-outline: Top-Level Agents (15)
+### Tools
+
+Agents interact with external systems through **tools** — structured interfaces provided
+by MCP servers and the VS Code runtime. Each agent's frontmatter declares a `tools:`
+allowlist that restricts which tools it can call. Common tool categories:
+
+- **MCP tools**: Cloud API wrappers (Azure pricing queries, GitHub operations, Terraform registry lookups)
+- **File tools**: Read and write workspace files (create artifacts, read prior step outputs)
+- **Terminal tools**: Execute CLI commands (Bicep build, Terraform validate, Azure CLI)
+- **Subagent tools**: Delegate to specialised subagents via `#runSubagent`
+
+### Handoffs
+
+Agents do not communicate directly. Instead, each agent produces **artifact files**
+in `agent-output/{project}/` that the next agent reads as input. The Conductor
+orchestrates this by delegating to one agent at a time, collecting its output,
+and routing to the next step. At approval gates, the Conductor writes a
+`00-handoff.md` summary document that enables session resume.
+
+## :material-account-supervisor-outline: Top-Level Agents (16)
 
 | Agent                    | Role                                  | Primary Skills                  |
 | ------------------------ | ------------------------------------- | ------------------------------- |
@@ -43,6 +62,7 @@ loaded into the system prompt when the agent is invoked.
 | 02-Requirements          | Captures project requirements         | azure-defaults, azure-artifacts |
 | 03-Architect             | WAF assessment and cost estimation    | azure-defaults                  |
 | 04-Design                | Diagrams and ADRs                     | azure-diagrams, azure-adr       |
+| 04g-Governance           | Policy discovery and compliance       | azure-defaults                  |
 | 05b-Bicep Planner        | Bicep implementation planning         | azure-bicep-patterns            |
 | 05t-Terraform Planner    | Terraform implementation planning     | terraform-patterns              |
 | 06b-Bicep CodeGen        | Bicep template generation             | azure-bicep-patterns            |
@@ -54,22 +74,24 @@ loaded into the system prompt when the agent is invoked.
 | 10-Challenger            | Standalone adversarial review         | —                               |
 | 11-Context Optimizer     | Context window audit and optimisation | context-optimizer               |
 
-## :material-account-cog-outline: Subagents (9)
+## :material-account-cog-outline: Subagents (11)
 
 Subagents are not user-invocable. They are delegated to by parent agents for isolated,
 specific tasks:
 
-| Subagent                      | Purpose                                | Invoked By          |
-| ----------------------------- | -------------------------------------- | ------------------- |
-| challenger-review-subagent    | Adversarial review of artifacts        | Steps 1, 2, 4, 5, 6 |
-| cost-estimate-subagent        | Azure Pricing MCP queries              | Steps 2, 7          |
-| governance-discovery-subagent | Azure Policy discovery via REST API    | Step 4              |
-| bicep-lint-subagent           | `bicep build` + `bicep lint`           | Step 5 (Bicep)      |
-| bicep-review-subagent         | Code review against AVM standards      | Step 5 (Bicep)      |
-| bicep-whatif-subagent         | `az deployment what-if` preview        | Step 6 (Bicep)      |
-| terraform-lint-subagent       | `terraform fmt` + `terraform validate` | Step 5 (Terraform)  |
-| terraform-review-subagent     | Code review against AVM-TF standards   | Step 5 (Terraform)  |
-| terraform-plan-subagent       | `terraform plan` preview               | Step 6 (Terraform)  |
+| Subagent                         | Purpose                                | Invoked By          |
+| -------------------------------- | -------------------------------------- | ------------------- |
+| challenger-review-subagent       | Adversarial review of artifacts        | Steps 1, 2, 4, 5, 6 |
+| challenger-review-batch-subagent | Batch multi-lens adversarial review    | Steps 2, 4, 5       |
+| challenger-review-codex-subagent | Fast adversarial review (Codex model)  | Steps 2, 4          |
+| cost-estimate-subagent           | Azure Pricing MCP queries              | Steps 2, 7          |
+| governance-discovery-subagent    | Azure Policy discovery via REST API    | Step 4              |
+| bicep-lint-subagent              | `bicep build` + `bicep lint`           | Step 5 (Bicep)      |
+| bicep-review-subagent            | Code review against AVM standards      | Step 5 (Bicep)      |
+| bicep-whatif-subagent            | `az deployment what-if` preview        | Step 6 (Bicep)      |
+| terraform-lint-subagent          | `terraform fmt` + `terraform validate` | Step 5 (Terraform)  |
+| terraform-review-subagent        | Code review against AVM-TF standards   | Step 5 (Terraform)  |
+| terraform-plan-subagent          | `terraform plan` preview               | Step 6 (Terraform)  |
 
 ## :material-sword-cross: The Challenger Pattern
 
@@ -130,4 +152,9 @@ This enables resume from any gate without needing to re-read all prior artefacts
 
 ---
 
-**Next:** [Skills & Instructions](skills-and-instructions.md) · [Workflow Engine & Quality](workflow-engine.md)
+!!! tip "Further Reading"
+
+    - [Core Concepts](four-pillars.md) — the four knowledge layers (agents, skills, instructions, registries)
+    - [Skills & Instructions](skills-and-instructions.md) — progressive skill loading and glob-based enforcement
+    - [Workflow Engine & Quality](workflow-engine.md) — DAG model, approval gates, circuit breakers
+    - [MCP Integration](mcp-integration.md) — the four MCP servers and their tool catalogs

--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -64,7 +64,7 @@ flowchart LR
   height="200" style="object-fit: cover; border-radius: 8px;"
   alt="Orchestra performance representing the Conductor pattern"></div><br/>
 
-The InfraOps Conductor (agent `01-Conductor`) is the master orchestrator. It does not
+The InfraOps Conductor (agent `01-Conductor`, also known as the Coordinator) is the master orchestrator. It does not
 generate infrastructure code or documentation itself. Instead, it:
 
 1. Reads the workflow DAG from `workflow-graph.json`
@@ -90,12 +90,17 @@ decision context. The new session resumes from the checkpoint by reading the sta
 
 **Model Selection**: The Conductor routes to different model tiers based on task complexity:
 
-| Tier           | Model             | Used By                                          |
-| -------------- | ----------------- | ------------------------------------------------ |
-| Primary        | Claude Opus 4.6   | Conductor, Steps 1–7 agents                      |
-| Review         | Claude Sonnet 4.6 | Challenger reviews, code reviews (A/B validated) |
-| Heavy API Work | GPT-5.3-Codex     | Governance discovery (batch REST API calls)      |
-| Utility        | GPT-4o-mini       | Session state updates, lightweight tasks         |
+!!! note "Model versions evolve"
+
+    The specific versions below reflect the current configuration. Check agent
+    frontmatter (`model:` field) for the latest selections.
+
+| Tier           | Model         | Used By                                          |
+| -------------- | ------------- | ------------------------------------------------ |
+| Primary        | Claude Opus   | Conductor, Steps 1–7 agents                      |
+| Review         | Claude Sonnet | Challenger reviews, code reviews (A/B validated) |
+| Heavy API Work | GPT Codex     | Governance discovery (batch REST API calls)      |
+| Utility        | GPT-4o-mini   | Session state updates, lightweight tasks         |
 
 **Subagent Integration Matrix**: The full mapping of which subagents are invoked by
 which parent agents is externalised to
@@ -147,3 +152,12 @@ flowchart TD
     Bicep --> AsBuilt
     Terraform --> AsBuilt
 ```
+
+---
+
+!!! tip "Further Reading"
+
+    - [Core Concepts](four-pillars.md) — agents, skills, instructions, and configuration registries
+    - [Agent Architecture](agents.md) — 16 top-level agents, 11 subagents, Challenger pattern
+    - [Workflow Engine & Quality](workflow-engine.md) — DAG model, session state, circuit breakers
+    - [MCP Integration](mcp-integration.md) — four MCP servers and tool catalogs

--- a/docs/how-it-works/four-pillars.md
+++ b/docs/how-it-works/four-pillars.md
@@ -2,7 +2,7 @@
 toc_depth: 3
 ---
 
-# :material-pillar: The Four Pillars
+# :material-pillar: Core Concepts
 
 The system's knowledge architecture is built on four distinct layers, each serving
 a specific purpose in the agent's context window.
@@ -102,3 +102,39 @@ It provides:
 
 This file is shorter than `AGENTS.md` and focused on VS Code-specific orchestration
 concerns rather than repository-wide conventions.
+
+## :material-tools: Tools and MCP Servers
+
+Agents do not call cloud APIs or execute commands directly. Instead, they invoke
+**tools** — structured interfaces provided by the Model Context Protocol (MCP)
+and the VS Code runtime. Tools give agents real-time access to external systems:
+
+- **MCP tools**: JSON-RPC endpoints that wrap cloud APIs. Each MCP server provides
+  a set of typed tools (e.g. `azure_price_search`, `azure_cost_estimate`) that agents
+  discover and call at runtime. The server handles authentication, caching, pagination,
+  and response formatting.
+- **VS Code tools**: Built-in capabilities like file reads/writes, terminal commands,
+  search, and subagent invocation.
+- **Handoffs**: Agents delegate to the next step by writing artifact files to
+  `agent-output/{project}/`. The next agent reads those files as input — there is no
+  direct message passing between agents.
+
+This project integrates four MCP servers:
+
+| Server            | Purpose                            | Transport          |
+| ----------------- | ---------------------------------- | ------------------ |
+| **GitHub MCP**    | Issues, PRs, code search, branches | HTTP (Copilot API) |
+| **Azure MCP**     | RBAC-aware Azure Resource Manager  | VS Code extension  |
+| **Azure Pricing** | Cost estimation (13 tools)         | stdio (Python)     |
+| **Terraform MCP** | Provider/module registry lookups   | stdio (Go)         |
+
+[:octicons-arrow-right-24: MCP Integration details](mcp-integration.md)
+
+---
+
+!!! tip "Further Reading"
+
+    - [Agent Architecture](agents.md) — 16 top-level agents, 11 subagents, the Challenger pattern
+    - [Skills & Instructions](skills-and-instructions.md) — progressive loading, glob-based enforcement
+    - [Workflow Engine & Quality](workflow-engine.md) — DAG model, approval gates, 35 validators
+    - [MCP Integration](mcp-integration.md) — four MCP servers and their tool catalogs

--- a/docs/how-it-works/index.md
+++ b/docs/how-it-works/index.md
@@ -20,7 +20,7 @@ production-grade Infrastructure as Code. The system coordinates 16 top-level age
 11 subagents through mandatory human approval gates, producing Bicep or Terraform templates
 that conform to Azure Well-Architected Framework principles, Azure Verified Modules standards,
 and organisational governance policies. The agents are supported by 18 skills, 27 instruction
-files, 3 Copilot hooks, and 5 MCP server integrations.
+files, 3 Copilot hooks, and 4 MCP server integrations.
 
 The core thesis is that **AI agents can reliably produce production-grade Azure infrastructure
 when properly orchestrated with guardrails**. The system achieves this through
@@ -40,13 +40,13 @@ are enforced as first-class concerns across all generated infrastructure.
 
   [:octicons-arrow-right-24: Architecture overview](architecture.md)
 
-- :material-pillar:{ .lg .middle } **The Four Pillars**
+- :material-pillar:{ .lg .middle } **Core Concepts**
 
   ***
 
   Agents, Skills, Instructions, and Configuration Registries — the knowledge layers.
 
-  [:octicons-arrow-right-24: Four pillars](four-pillars.md)
+  [:octicons-arrow-right-24: Core concepts](four-pillars.md)
 
 - :material-robot:{ .lg .middle } **Agent Architecture**
 
@@ -68,7 +68,7 @@ are enforced as first-class concerns across all generated infrastructure.
 
   ***
 
-  DAG model, approval gates, session state, 28 validators, Copilot hooks, and circuit breakers.
+  DAG model, approval gates, session state, 35 validators, Copilot hooks, and circuit breakers.
 
   [:octicons-arrow-right-24: Workflow & quality](workflow-engine.md)
 
@@ -76,7 +76,7 @@ are enforced as first-class concerns across all generated infrastructure.
 
   ***
 
-  Five MCP servers: GitHub, Microsoft Learn, Azure, Pricing, and Terraform Registry.
+  Four MCP servers: GitHub, Azure, Pricing, and Terraform Registry.
 
   [:octicons-arrow-right-24: MCP servers](mcp-integration.md)
 
@@ -114,7 +114,7 @@ This project adopts the same pattern: `AGENTS.md` is approximately 250 lines and
 **Enforce invariants, not implementations.** Rather than prescribing step-by-step procedures,
 the Harness Engineering approach encodes strict boundaries (architectural layering rules,
 naming conventions, security requirements) and lets agents choose their own path within those
-constraints. This project enforces invariants mechanically: 33 validation scripts check
+constraints. This project enforces invariants mechanically: 35 validation scripts check
 naming conventions, template compliance, governance references, and architectural rules.
 
 **Human taste gets encoded.** When a human reviewer catches a pattern issue, the fix is
@@ -257,7 +257,7 @@ This project weaves all three into a system purpose-built for Azure infrastructu
 | ---------------------- | ------------------------------------ | ----------------------------------- | -------------------------------- | ------------------------------------------------------------- |
 | Knowledge management   | Repo is system of record             | Shared knowledge base               | `AGENTS.md` + `progress.txt`     | Skills + instructions + `agent-output/`                       |
 | Context management     | Map, not manual                      | Context shredding                   | Fresh context per iteration      | Progressive skill loading + 3-tier compression                |
-| Quality enforcement    | Mechanical enforcement of invariants | Pre-push hooks + anomaly detection  | Mandatory CI feedback loops      | 28 validators + pre-commit/push hooks + 3 Copilot hooks       |
+| Quality enforcement    | Mechanical enforcement of invariants | Pre-push hooks + anomaly detection  | Mandatory CI feedback loops      | 35 validators + pre-commit/push hooks + 3 Copilot hooks       |
 | Workflow orchestration | Structured step progression          | Workflow engine DAG                 | Bash loop + `prd.json` task list | `workflow-graph.json` + Conductor agent                       |
 | Concurrency safety     | —                                    | Claim-based locking                 | Single-instance sequential loop  | Session state v2.0 with lock/claim model                      |
 | Task decomposition     | —                                    | —                                   | One context window per story     | One artefact per workflow step                                |

--- a/docs/how-it-works/mcp-integration.md
+++ b/docs/how-it-works/mcp-integration.md
@@ -175,6 +175,15 @@ agent-output/{project}/                      # All agent-generated artefacts
 infra/
   bicep/{project}/                           # Bicep templates
   terraform/{project}/                       # Terraform configurations
-scripts/                                     # 27 validation scripts
+scripts/                                     # 35 validation scripts
 mcp/azure-pricing-mcp/                       # Custom Azure Pricing MCP server
 ```
+
+---
+
+!!! tip "Further Reading"
+
+    - [System Architecture](architecture.md) — the Conductor pattern and model selection
+    - [Core Concepts](four-pillars.md) — high-level overview of tools and MCP
+    - [Agent Architecture](agents.md) — which agents use which MCP servers
+    - [Workflow Engine & Quality](workflow-engine.md) — circuit breakers and validation systems

--- a/docs/how-it-works/skills-and-instructions.md
+++ b/docs/how-it-works/skills-and-instructions.md
@@ -111,3 +111,12 @@ rules across ALL projects (Bicep and Terraform):
 Following the Golden Principle "Mechanical Enforcement Over Documentation," every
 instruction has a corresponding validation script. The rule is: if it can be a linter
 check, it should be one. Documentation is for humans; machines enforce rules.
+
+---
+
+!!! tip "Further Reading"
+
+    - [Core Concepts](four-pillars.md) — the four knowledge layers and how they interact
+    - [Agent Architecture](agents.md) — how agents load and use skills via progressive disclosure
+    - [Workflow Engine & Quality](workflow-engine.md) — 35 validators that enforce instruction rules
+    - [MCP Integration](mcp-integration.md) — external tool interfaces available to agents

--- a/docs/how-it-works/workflow-engine.md
+++ b/docs/how-it-works/workflow-engine.md
@@ -142,11 +142,11 @@ experienced 5 forced context summarisations in a single 3h39m session.
 
 ## :material-shield-check-outline: Quality and Safety Systems
 
-### 28 Validation Scripts
+### 35 Validation Scripts
 
-Every convention is backed by a machine-enforceable check. The 26 script files drive
-the validation suite, organised into two parallel groups: `validate:_node` (22 Node.js
-validators) and `validate:_external` (5 external tool validators):
+Every convention is backed by a machine-enforceable check. The validation suite runs
+via two parallel groups: `validate:_node` (23 Node.js
+validators) and `validate:_external` (4 external tool validators):
 
 | Category            | Validators                                                                                |
 | ------------------- | ----------------------------------------------------------------------------------------- |
@@ -229,3 +229,12 @@ at runtime:
 
 Hooks are defined in `hooks.json` files with type (`command`), path to shell script,
 and timeout. They run automatically — agents do not invoke them explicitly.
+
+---
+
+!!! tip "Further Reading"
+
+    - [System Architecture](architecture.md) — the 8-step workflow, Conductor pattern, dual IaC tracks
+    - [Core Concepts](four-pillars.md) — agents, skills, instructions, and configuration registries
+    - [Agent Architecture](agents.md) — handoffs, the Challenger pattern, context shredding
+    - [MCP Integration](mcp-integration.md) — four MCP servers and how agents invoke tools

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,9 @@ accelerate Azure infrastructure delivery with AI-assisted workflows.
 sequenceDiagram
     autonumber
     participant U as 👤 User
-    participant C as 🎼 Conductor
+    participant C as 🎼 Conductor Agent
     participant Agents as 🤖 Agents
-    participant X as ⚔️ Challenger
+    participant X as ⚔️ Challenger Agent
 
     Note over C: AI prepares · Humans decide
 
@@ -183,3 +183,33 @@ See the [Changelog](CHANGELOG.md) for the full release history.
 - **Troubleshooting**: [Troubleshooting Guide](troubleshooting.md)
 - **MicroHack**: [Hands-on guided challenge](https://jonathan-vella.github.io/microhack-agentic-infraops/)
   — build Azure infrastructure end-to-end using AI agents
+
+---
+
+## :material-presentation-play: Resources
+
+<div class="grid cards" markdown>
+
+- :material-youtube:{ .lg .middle } **Watch the Demo**
+
+  ***
+
+  See Agentic InfraOps in action — full workflow walkthrough from requirements to deployment.
+
+  <div class="video-wrapper">
+    <iframe width="100%" height="315"
+      src="https://www.youtube.com/embed/Hao3F52sZUc"
+      title="Agentic InfraOps Demo" frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen></iframe>
+  </div>
+
+- :material-presentation:{ .lg .middle } **Presentation Deck**
+
+  ***
+
+  Download the slide deck for stakeholder presentations and team introductions.
+
+  [:material-download: Download PPTX](assets/downloads/agentic-infraops.PPTX){ .md-button }
+
+</div>

--- a/docs/prompt-guide/index.md
+++ b/docs/prompt-guide/index.md
@@ -52,7 +52,7 @@ infrastructure.
 
 ### Agents
 
-| Agent                  | Persona       | Step | Purpose                                        |
+| Agent                  | Codename      | Step | Purpose                                        |
 | ---------------------- | ------------- | ---- | ---------------------------------------------- |
 | **InfraOps Conductor** | 🎼 Maestro    | All  | Orchestrates the full 8-step workflow          |
 | **Requirements**       | 📜 Scribe     | 1    | Captures business and technical requirements   |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,6 +31,13 @@ Get running in 10 minutes.
 | Docker Desktop         | [Download](https://www.docker.com/products/docker-desktop/) |
 | Azure subscription     | Optional for learning                                       |
 
+!!! info "Docker is required"
+
+    A Docker-compatible runtime is needed for the dev container. [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+    is the most common choice. Free alternatives include [Rancher Desktop](https://rancherdesktop.io/),
+    [Colima](https://github.com/abiosoft/colima) (macOS), and [Podman](https://podman.io/) (Linux/macOS).
+    See [Dev Container Setup](dev-containers.md) for detailed installation options.
+
 ## :material-source-repository: Step 1: Create Your Repository from the Template
 
 1. Go to the
@@ -59,6 +66,13 @@ code my-infraops-project
    GitHub username and the repository name you chose in Step 1.
 
 ## :material-docker: Step 3: Open in Dev Container
+
+!!! tip "What is a dev container?"
+
+    A [dev container](https://containers.dev/) is a pre-configured development environment
+    that runs inside a Docker container. It ensures every contributor has identical tools,
+    extensions, and settings — no manual setup required. See the
+    [Dev Container Setup](dev-containers.md) page for details.
 
 1. Press `F1` (or `Ctrl+Shift+P`)
 2. Type: `Dev Containers: Reopen in Container`
@@ -116,7 +130,7 @@ take precedence for experimental features like subagent invocation.
 
 ### Option A: InfraOps Conductor (Recommended)
 
-The Conductor (🎼 Maestro) orchestrates the complete 8-step workflow:
+The Conductor (🎼 Maestro), also known as the Coordinator, orchestrates the complete 8-step workflow:
 
 1. Press `Ctrl+Shift+I` to open Copilot Chat
 2. Select **InfraOps Conductor** from the agent dropdown
@@ -147,7 +161,9 @@ Invoke agents directly for specific tasks:
 The agents work in sequence with handoffs. Steps 1-3.5 and 7 are shared;
 steps 4-6 route to **Bicep** or **Terraform** agents based on your `iac_tool` selection.
 
-| Step | Agent                                 | Persona       | What Happens                |
+Each agent has a thematic codename for easy reference in documentation and prompts.
+
+| Step | Agent                                 | Codename      | What Happens                |
 | ---- | ------------------------------------- | ------------- | --------------------------- |
 | 1    | `requirements`                        | 📜 Scribe     | Captures requirements       |
 | 2    | `architect`                           | 🏛️ Oracle     | WAF assessment              |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,9 +12,9 @@ toc_depth: 2
 
 > Common issues and solutions for Agentic InfraOps
 
-## :material-account-card-outline: Agent Personas Quick Reference
+## :material-account-card-outline: Agent Codenames Quick Reference
 
-| Agent              | Persona       | Common Issues                    |
+| Agent              | Codename      | Common Issues                    |
 | ------------------ | ------------- | -------------------------------- |
 | InfraOps Conductor | 🎼 Maestro    | Subagent invocation not working  |
 | requirements       | 📜 Scribe     | Not appearing in list            |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -20,7 +20,8 @@ code. The system supports **dual IaC tracks** — Bicep and Terraform — sharin
 architecture, design, and governance steps (1-3.5) then diverging into track-specific planning,
 code generation, and deployment (steps 4-6) before converging again for documentation (step 7).
 
-The **InfraOps Conductor** (🎼 Maestro) orchestrates the complete workflow, routing to
+The **InfraOps Conductor** (🎼 Maestro, also referred to as the Coordinator)
+orchestrates the complete workflow, routing to
 Bicep or Terraform agents based on the `iac_tool` field in `01-requirements.md`,
 while enforcing mandatory approval gates.
 
@@ -45,6 +46,83 @@ The Conductor resolves agent paths and models via `.github/agent-registry.json`.
 ## :material-robot-outline: Agent Architecture
 
 ### The Conductor Pattern
+
+The Conductor (also called Coordinator) orchestrates the entire workflow by delegating
+to specialised agents step by step, enforcing approval gates, and maintaining session state.
+The following diagram shows the end-to-end flow:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as 👤 User
+    participant C as 🎼 Conductor Agent
+    participant Agents as 🤖 Agents
+    participant X as ⚔️ Challenger Agent
+
+    Note over C: AI prepares · Humans decide
+
+    U->>C: Describe infrastructure intent
+    C->>Agents: 📋 Gather requirements
+    Agents-->>C: 01-requirements.md
+    C->>X: Challenge requirements
+    X-->>C: Findings
+    C->>U: Present for review
+
+    rect rgba(255, 200, 0, 0.15)
+    Note over U,C: 🛑 APPROVAL GATE
+    U-->>C: ✅ Approve
+    end
+
+    C->>Agents: 🏛️ Architecture + 💰 Cost
+    Agents-->>C: 02-assessment.md
+    C->>X: Challenge architecture
+    C->>U: Present for review
+
+    rect rgba(255, 200, 0, 0.15)
+    Note over U,C: 🛑 APPROVAL GATE
+    U-->>C: ✅ Approve
+    end
+
+    C->>Agents: 📐 IaC Plan + Governance
+    Note right of Agents: Bicep or Terraform track
+    Agents-->>C: 04-plan.md + constraints
+    C->>X: Challenge plan
+    C->>U: Present for review
+
+    rect rgba(255, 200, 0, 0.15)
+    Note over U,C: 🛑 APPROVAL GATE
+    U-->>C: ✅ Approve
+    end
+
+    C->>Agents: ⚒️ Generate IaC (AVM-first)
+    Note right of Agents: lint → review → validate
+    Agents-->>C: infra/{bicep,terraform}/{project}
+
+    rect rgba(255, 200, 0, 0.15)
+    Note over U,C: 🛑 APPROVAL GATE
+    U-->>C: ✅ Approve for deploy
+    end
+
+    C->>Agents: 🚀 Deploy to Azure
+    Note right of Agents: what-if / plan preview first
+    Agents-->>C: 06-deployment-summary.md
+
+    rect rgba(255, 200, 0, 0.15)
+    Note over U,C: 🛑 VERIFICATION
+    U-->>C: ✅ Verify resources
+    end
+
+    C->>Agents: 📚 Generate as-built docs
+    Agents-->>C: 07-*.md documentation suite
+    C->>U: Present complete documentation
+
+    Note over U,Agents: ✅ AI Orchestrated · Human Governed · Azure Ready
+```
+
+### Agent Delegation Graph
+
+The detailed delegation graph below shows how the Conductor routes to each
+specialised agent and how subagents are invoked for validation:
 
 ```mermaid
 %%{init: {'theme':'neutral'}}%%
@@ -137,15 +215,15 @@ graph TB
 
 ### Primary Orchestrator
 
-| Agent                  | Persona    | Role                                    | Model           |
-| ---------------------- | ---------- | --------------------------------------- | --------------- |
-| **InfraOps Conductor** | 🎼 Maestro | Master orchestrator for 8-step workflow | Claude Opus 4.6 |
+| Agent                  | Codename   | Role                                    | Model                |
+| ---------------------- | ---------- | --------------------------------------- | -------------------- |
+| **InfraOps Conductor** | 🎼 Maestro | Master orchestrator for 8-step workflow | Claude Opus (latest) |
 
 ### Core Agents (7 Steps)
 
 Steps 1-3 and 7 are shared. Steps 4-6 have Bicep and Terraform variants.
 
-| Step | Agent              | Persona       | Role                                 | Artifact                                             |
+| Step | Agent              | Codename      | Role                                 | Artifact                                             |
 | ---- | ------------------ | ------------- | ------------------------------------ | ---------------------------------------------------- |
 | 1    | `requirements`     | 📜 Scribe     | Captures infrastructure requirements | `01-requirements.md`                                 |
 | 2    | `architect`        | 🏛️ Oracle     | WAF assessment and design decisions  | `02-architecture-assessment.md`                      |
@@ -179,7 +257,7 @@ Steps 1-3 and 7 are shared. Steps 4-6 have Bicep and Terraform variants.
 
 ### Standalone Agents
 
-| Agent        | Persona       | Role                                                            |
+| Agent        | Codename      | Role                                                            |
 | ------------ | ------------- | --------------------------------------------------------------- |
 | `challenger` | ⚔️ Challenger | Adversarial reviewer — challenges architecture, plans, and code |
 | `diagnose`   | 🔍 Sentinel   | Resource health assessment and troubleshooting                  |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: Azure infrastructure engineered by AI agents — from requirem
 repo_url: https://github.com/jonathan-vella/azure-agentic-infraops
 repo_name: jonathan-vella/azure-agentic-infraops
 edit_uri: edit/main/docs/
-copyright: "&copy; 2025 Jonathan Vella. Distributed under the MIT License."
+copyright: "&copy; 2025-2026 Jonathan Vella. Distributed under the MIT License."
 
 theme:
   name: material
@@ -99,7 +99,7 @@ nav:
       - How It Works:
           - Overview: how-it-works/index.md
           - System Architecture: how-it-works/architecture.md
-          - The Four Pillars: how-it-works/four-pillars.md
+          - Core Concepts: how-it-works/four-pillars.md
           - Agent Architecture: how-it-works/agents.md
           - Skills & Instructions: how-it-works/skills-and-instructions.md
           - Workflow Engine & Quality: how-it-works/workflow-engine.md


### PR DESCRIPTION
## Summary

Comprehensive documentation audit — accuracy fixes plus content improvements across the GitHub Pages site.

## Accuracy Fixes

- MCP server count corrected 5 → 4 (GitHub, Azure, Azure Pricing, Terraform)
- Validation script count corrected → 35 (all instances updated)
- Top-level agent count corrected → 16 (added `04g-Governance`)
- Subagent count corrected → 11 (added `challenger-review-batch-subagent`, `challenger-review-codex-subagent`)
- Instruction file count stays 27 (verified on disk)
- Copyright year updated 2025 → 2025-2026
- Hardcoded model versions softened (agents.md, architecture.md, faq.md)

## Content Changes

- **Rename**: "The Four Pillars" → "Core Concepts" (nav + page title + all references)
- **Rename**: "Persona" → "Codename" everywhere in user-facing docs (workflow.md, quickstart.md, troubleshooting.md, prompt-guide, doc-standards.md)
- **Conductor**: added "(also known as the Coordinator)" parenthetical in architecture.md and workflow.md
- **Tools & MCP section**: added to Core Concepts page with 4-server table
- **Tools/Handoffs**: added explanation subsection to agents.md
- **Further Reading**: added `!!! tip` admonitions to all six how-it-works pages
- **Sequence diagram**: full Conductor/agent sequence diagram added to workflow.md
- **Quickstart**: Docker prerequisite info box + dev container explainer tip
- **Resources section**: YouTube embed + PPTX download button added to home page
- **Diagram labels**: "+Agent" suffix added to Conductor/Challenger in home page mermaid diagram
- **New file**: `docs/assets/downloads/agentic-infraops.PPTX` served via GitHub Pages

## Verification

- `mkdocs build --strict` → 0 warnings, 0 errors
- `npm run lint:md` → Summary: 0 error(s)
- All pre-commit hooks passed (link-check, markdown-lint, commitlint)