### PR TITLE
docs: add governance step to architecture diagrams, remove brittle counts

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -370,7 +370,7 @@ for Agentic InfraOps methodology.
 
 A reusable knowledge module stored in `.github/skills/` that agents can invoke. Unlike agents,
 skills don't have their own chat persona — they provide domain knowledge that agents use.
-18 skills are organized across conventions, document creation, infrastructure patterns,
+Skills are organized across conventions, document creation, infrastructure patterns,
 workflow automation, and troubleshooting categories.
 
 📁 **See**: [.github/skills/](https://github.com/jonathan-vella/azure-agentic-infraops/tree/main/.github/skills)

--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -37,6 +37,8 @@ flowchart LR
     S2["Step 2\nArchitecture"]
     G2{{"Gate 2\n🔒 Approval"}}:::gate
     S3["Step 3\nDesign\n(optional)"]
+    S35["Step 3.5\nGovernance"]
+    G25{{"Gate 2.5\n🔒 Approval"}}:::gate
     S4["Step 4\nIaC Plan"]
     G3{{"Gate 3\n🔒 Approval"}}:::gate
     S5["Step 5\nIaC Code"]
@@ -45,7 +47,7 @@ flowchart LR
     G5{{"Gate 5\n🔒 Approval"}}:::gate
     S7["Step 7\nAs-Built Docs"]:::endNode
 
-    S1 --> G1 --> S2 --> G2 --> S3 --> S4 --> G3 --> S5 --> G4 --> S6 --> G5 --> S7
+    S1 --> G1 --> S2 --> G2 --> S3 --> S35 --> G25 --> S4 --> G3 --> S5 --> G4 --> S6 --> G5 --> S7
 ```
 
 | Step | Phase        | Agent                              | Output                                   | Review            |
@@ -53,7 +55,8 @@ flowchart LR
 | 1    | Requirements | 02-Requirements                    | `01-requirements.md`                     | 1 challenger pass |
 | 2    | Architecture | 03-Architect                       | `02-architecture-assessment.md` + cost   | 3+1 passes        |
 | 3    | Design (opt) | 04-Design                          | `03-des-*.{py,png,md}`                   | —                 |
-| 4    | IaC Plan     | 05b-Bicep Planner / 05t-TF Planner | `04-implementation-plan.md` + governance | 1+3 passes        |
+| 3.5  | Governance   | 04g-Governance                     | `04-governance-constraints.md/.json`     | —                 |
+| 4    | IaC Plan     | 05b-Bicep Planner / 05t-TF Planner | `04-implementation-plan.md`              | 1+3 passes        |
 | 5    | IaC Code     | 06b-Bicep CodeGen / 06t-TF CodeGen | `infra/bicep/` or `infra/terraform/`     | 3 passes          |
 | 6    | Deploy       | 07b-Bicep Deploy / 07t-TF Deploy   | `06-deployment-summary.md`               | 1 pass            |
 | 7    | As-Built     | 08-As-Built                        | `07-*.md` documentation suite            | —                 |

--- a/docs/how-it-works/four-pillars.md
+++ b/docs/how-it-works/four-pillars.md
@@ -136,5 +136,5 @@ This project integrates four MCP servers:
 
     - [Agent Architecture](agents.md) — 16 top-level agents, 11 subagents, the Challenger pattern
     - [Skills & Instructions](skills-and-instructions.md) — progressive loading, glob-based enforcement
-    - [Workflow Engine & Quality](workflow-engine.md) — DAG model, approval gates, 35 validators
+    - [Workflow Engine & Quality](workflow-engine.md) — DAG model, approval gates, validators
     - [MCP Integration](mcp-integration.md) — four MCP servers and their tool catalogs

--- a/docs/how-it-works/index.md
+++ b/docs/how-it-works/index.md
@@ -19,13 +19,13 @@ through a structured 8-step workflow to transform Azure infrastructure requireme
 production-grade Infrastructure as Code. The system coordinates 16 top-level agents and
 11 subagents through mandatory human approval gates, producing Bicep or Terraform templates
 that conform to Azure Well-Architected Framework principles, Azure Verified Modules standards,
-and organisational governance policies. The agents are supported by 18 skills, 27 instruction
-files, 3 Copilot hooks, and 4 MCP server integrations.
+and organisational governance policies. The agents are supported by reusable skills, instruction
+files, Copilot hooks, and MCP server integrations.
 
 The core thesis is that **AI agents can reliably produce production-grade Azure infrastructure
 when properly orchestrated with guardrails**. The system achieves this through
 a layered knowledge architecture (agents, skills, instructions, registries), mechanical enforcement
-of invariants via 35 validation scripts, and a human-in-the-loop design
+of invariants via automated validation scripts, and a human-in-the-loop design
 that preserves operator control at every critical decision point. Cost governance (budget alerts,
 forecast notifications, anomaly detection) and template repeatability (zero hardcoded values)
 are enforced as first-class concerns across all generated infrastructure.
@@ -68,7 +68,7 @@ are enforced as first-class concerns across all generated infrastructure.
 
   ***
 
-  DAG model, approval gates, session state, 35 validators, Copilot hooks, and circuit breakers.
+  DAG model, approval gates, session state, validators, Copilot hooks, and circuit breakers.
 
   [:octicons-arrow-right-24: Workflow & quality](workflow-engine.md)
 
@@ -109,12 +109,12 @@ and instructions, and all decisions in Architecture Decision Records.
 failed: context is a scarce resource, and a giant instruction file crowds out the task.
 Instead, they treat `AGENTS.md` as a table of contents that points to deeper sources.
 This project adopts the same pattern: `AGENTS.md` is approximately 250 lines and points to
-18 skills, 27 instruction files, and multiple configuration registries.
+skills, instruction files, and multiple configuration registries.
 
 **Enforce invariants, not implementations.** Rather than prescribing step-by-step procedures,
 the Harness Engineering approach encodes strict boundaries (architectural layering rules,
 naming conventions, security requirements) and lets agents choose their own path within those
-constraints. This project enforces invariants mechanically: 35 validation scripts check
+constraints. This project enforces invariants mechanically: validation scripts check
 naming conventions, template compliance, governance references, and architectural rules.
 
 **Human taste gets encoded.** When a human reviewer catches a pattern issue, the fix is
@@ -257,7 +257,7 @@ This project weaves all three into a system purpose-built for Azure infrastructu
 | ---------------------- | ------------------------------------ | ----------------------------------- | -------------------------------- | ------------------------------------------------------------- |
 | Knowledge management   | Repo is system of record             | Shared knowledge base               | `AGENTS.md` + `progress.txt`     | Skills + instructions + `agent-output/`                       |
 | Context management     | Map, not manual                      | Context shredding                   | Fresh context per iteration      | Progressive skill loading + 3-tier compression                |
-| Quality enforcement    | Mechanical enforcement of invariants | Pre-push hooks + anomaly detection  | Mandatory CI feedback loops      | 35 validators + pre-commit/push hooks + 3 Copilot hooks       |
+| Quality enforcement    | Mechanical enforcement of invariants | Pre-push hooks + anomaly detection  | Mandatory CI feedback loops      | Validators + pre-commit/push hooks + Copilot hooks            |
 | Workflow orchestration | Structured step progression          | Workflow engine DAG                 | Bash loop + `prd.json` task list | `workflow-graph.json` + Conductor agent                       |
 | Concurrency safety     | —                                    | Claim-based locking                 | Single-instance sequential loop  | Session state v2.0 with lock/claim model                      |
 | Task decomposition     | —                                    | —                                   | One context window per story     | One artefact per workflow step                                |

--- a/docs/how-it-works/mcp-integration.md
+++ b/docs/how-it-works/mcp-integration.md
@@ -153,9 +153,9 @@ AGENTS.md                                    # Table of contents for all agents
   copilot-instructions.md                    # VS Code Copilot orchestration
   agent-registry.json                        # Agent role → file/model/skills
   skill-affinity.json                        # Skill/agent affinity weights
-  agents/                                    # 16 top-level agent definitions
-    _subagents/                              # 11 subagent definitions
-  skills/                                    # 18 skill packages
+  agents/                                    # Top-level agent definitions
+    _subagents/                              # Subagent definitions
+  skills/                                    # Skill packages
     workflow-engine/                          # DAG, workflow graph
     context-shredding/                       # Runtime compression
     session-resume/                          # State tracking + resume protocol
@@ -167,7 +167,7 @@ AGENTS.md                                    # Table of contents for all agents
     iac-common/                              # Deploy patterns + circuit breaker
     github-operations/                       # GitHub MCP + CLI + Smart PR Flow
     ...
-  instructions/                              # 27 instruction files (glob-based)
+  instructions/                              # Instruction files (glob-based)
 agent-output/{project}/                      # All agent-generated artefacts
   00-session-state.json                      # Machine-readable workflow state
   00-handoff.md                              # Human-readable gate summary
@@ -175,7 +175,7 @@ agent-output/{project}/                      # All agent-generated artefacts
 infra/
   bicep/{project}/                           # Bicep templates
   terraform/{project}/                       # Terraform configurations
-scripts/                                     # 35 validation scripts
+scripts/                                     # Validation scripts
 mcp/azure-pricing-mcp/                       # Custom Azure Pricing MCP server
 ```
 

--- a/docs/how-it-works/skills-and-instructions.md
+++ b/docs/how-it-works/skills-and-instructions.md
@@ -35,7 +35,7 @@ Skills implement three levels of disclosure:
 
 ### Skill Catalog
 
-The system contains 18 skills across several domains:
+The system contains the following skills across several domains:
 
 | Domain               | Skills                                                              |
 | -------------------- | ------------------------------------------------------------------- |
@@ -118,5 +118,5 @@ check, it should be one. Documentation is for humans; machines enforce rules.
 
     - [Core Concepts](four-pillars.md) — the four knowledge layers and how they interact
     - [Agent Architecture](agents.md) — how agents load and use skills via progressive disclosure
-    - [Workflow Engine & Quality](workflow-engine.md) — 35 validators that enforce instruction rules
+    - [Workflow Engine & Quality](workflow-engine.md) — validators that enforce instruction rules
     - [MCP Integration](mcp-integration.md) — external tool interfaces available to agents

--- a/docs/how-it-works/workflow-engine.md
+++ b/docs/how-it-works/workflow-engine.md
@@ -43,6 +43,8 @@ flowchart TD
     S2["step-2: Architecture"]
     G2{{"gate-2: Approval"}}:::gate
     S3["step-3: Design"]
+    S35["step-3.5: Governance"]
+    G25{{"gate-2.5: Approval"}}:::gate
     S4B["step-4b: Bicep Plan"]
     S4T["step-4t: TF Plan"]
     G3{{"gate-3: Approval"}}:::gate
@@ -56,8 +58,9 @@ flowchart TD
 
     S1 --> G1 --> S2 --> G2
     G2 --> S3
-    G2 --> S4B & S4T
-    S3 --> S4B & S4T
+    S3 --> S35
+    S35 --> G25
+    G25 --> S4B & S4T
     S4B & S4T --> G3
     G3 --> S5B & S5T
     S5B & S5T --> G4
@@ -142,11 +145,11 @@ experienced 5 forced context summarisations in a single 3h39m session.
 
 ## :material-shield-check-outline: Quality and Safety Systems
 
-### 35 Validation Scripts
+### Validation Scripts
 
 Every convention is backed by a machine-enforceable check. The validation suite runs
-via two parallel groups: `validate:_node` (23 Node.js
-validators) and `validate:_external` (4 external tool validators):
+via two parallel groups: `validate:_node` (Node.js
+validators) and `validate:_external` (external tool validators):
 
 | Category            | Validators                                                                                |
 | ------------------- | ----------------------------------------------------------------------------------------- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,7 +162,7 @@ sequenceDiagram
 |                 |                                       |
 | --------------- | ------------------------------------- |
 | **Agents**      | 16 primary + 11 subagents             |
-| **Skills**      | 18 reusable domain knowledge modules  |
+| **Skills**      | Reusable domain knowledge modules     |
 | **IaC Tracks**  | Bicep and Terraform (dual-track)      |
 | **MCP Servers** | Azure, Pricing, Terraform, GitHub     |
 | **Workflow**    | 8 steps with mandatory approval gates |


### PR DESCRIPTION
## Summary

Fixes two issues:

1. **Missing Governance step** — Step 3.5 (04g-Governance agent) was absent from the architecture page's mermaid diagram and workflow table, and from the workflow-engine DAG diagram.

2. **Brittle hardcoded counts** — Removed specific numbers for skills, instructions, scripts, and validators across all docs. These counts change frequently and go stale quickly. Agent/subagent counts (16 + 11) are kept since they change rarely.

## Changes

### Governance step added
- [architecture.md](docs/how-it-works/architecture.md) — Added Step 3.5 + Gate 2.5 to mermaid flowchart; added Governance row to workflow table
- [workflow-engine.md](docs/how-it-works/workflow-engine.md) — Added step-3.5 + gate-2.5 to DAG mermaid diagram

### Brittle counts removed (8 files)
Replaced hardcoded numbers like "18 skills", "27 instructions", "35 validators" with generic descriptions:

| File | Counts removed |
|---|---|
| `docs/how-it-works/index.md` | 18 skills, 27 instructions, 35 validators (×4 instances) |
| `docs/how-it-works/skills-and-instructions.md` | 18 skills, 35 validators |
| `docs/how-it-works/mcp-integration.md` | 18 skills, 27 instructions, 35 scripts (file tree comments) |
| `docs/how-it-works/four-pillars.md` | 35 validators |
| `docs/how-it-works/workflow-engine.md` | 35 heading, 23/4 split |
| `docs/index.md` | 18 skills |
| `docs/GLOSSARY.md` | 18 skills |

## Verification

- `mkdocs build --strict` → 0 warnings, 0 errors
- `npm run lint:md` → 0 errors
- All pre-commit hooks passed