### PR TITLE
docs: comprehensive peer-review accuracy and UX fixes

### DIFF
--- a/.github/prompts/plan-docsPeerReview.prompt.md
+++ b/.github/prompts/plan-docsPeerReview.prompt.md
@@ -1,71 +1,111 @@
 ---
-description: "Multi-model peer review of all published documentation with adversarial passes. Uses GPT 5.4 and Sonnet 4.6 subagents for independent reviews, then reconciles findings."
+description: "Review all published docs for accuracy, UX, and contradictions using three independent reviewers, then consolidate into an actionable triage report."
 agent: agent
-model: "Claude Opus 4.6 (1M context)(Internal only)"
-tools:vscode, execute, read, agent, browser, edit, search, web, todo
+tools: read, agent, search
+argument-hint: "Optional: scope to a specific docs section (e.g., 'how-it-works only')"
 ---
 
 # Docs Peer Review
 
-Orchestrate a multi-model peer review of every published documentation page in `docs/`.
-Two independent reviewer passes run first, then an adversarial pass, then reconciliation.
+Orchestrate a peer review of every published documentation page in `docs/`.
+Two independent reviewer passes run sequentially, then an adversarial pass,
+then reconciliation into a prioritised triage report.
 
 ## Scope
 
-Published pages only (matches `mkdocs.yml` nav). Excludes `docs/exec-plans/` and
-`docs/presenter/`.
+Published pages only. Excludes `docs/exec-plans/` and `docs/presenter/`
+(per `mkdocs.yml` `exclude_docs` directive).
 
-### File inventory
+### Step 0 — Build file inventory dynamically
 
-| Section                 | Files                                                                                                                                                     |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Landing                 | `docs/index.md`                                                                                                                                           |
-| Getting Started         | `docs/quickstart.md`, `docs/dev-containers.md`                                                                                                            |
-| Concepts — How It Works | `docs/how-it-works/index.md`, `architecture.md`, `four-pillars.md`, `agents.md`, `skills-and-instructions.md`, `workflow-engine.md`, `mcp-integration.md` |
-| Concepts — Workflow     | `docs/workflow.md`                                                                                                                                        |
-| Guides — Prompt Guide   | `docs/prompt-guide/index.md`, `best-practices.md`, `workflow-prompts.md`, `reference.md`                                                                  |
-| Guides                  | `docs/troubleshooting.md`                                                                                                                                 |
-| Reference               | `docs/GLOSSARY.md`, `docs/faq.md`                                                                                                                         |
-| Project                 | `docs/CONTRIBUTING.md`, `docs/CHANGELOG.md`                                                                                                               |
+Before running any reviewer, read `mkdocs.yml` and extract all file paths from the
+`nav:` section. This is the authoritative list of published pages. Do NOT rely on a
+hardcoded table — the nav changes over time.
+
+Expected sections (for reference, not as source of truth):
+
+- Landing, Getting Started, Concepts (How It Works + Workflow), Guides (Prompt Guide +
+  Troubleshooting), Reference (Glossary, FAQ), Project (Contributing, Changelog)
+
+Known filename note: `four-pillars.md` renders as "Core Concepts" in the nav.
+
+### Source-of-truth files for cross-referencing
+
+Reviewers should validate docs claims against these files:
+
+| File                          | What it proves                        |
+| ----------------------------- | ------------------------------------- |
+| `.github/agents/*.agent.md`   | Top-level agent names and count       |
+| `.github/agents/_subagents/`  | Subagent names and count              |
+| `.github/skills/*/SKILL.md`   | Skill names and count                 |
+| `.github/instructions/`       | Instruction file names                |
+| `.github/agent-registry.json` | Agent → file/model/skills mapping     |
+| `.github/skill-affinity.json` | Skill → agent affinity weights        |
+| `.vscode/mcp.json`            | MCP server names and config           |
+| `package.json`                | Validation script names               |
+| `mkdocs.yml`                  | Nav structure and published page list |
+| `AGENTS.md`                   | Project conventions table of contents |
 
 ## Workflow
 
-### Phase 1 — Independent reviews (parallel)
+### Phase 1 — Independent reviews (sequential)
 
-Run two subagent reviews in parallel. Each reviewer reads every file above and
-produces a structured findings list.
+Run two subagent reviews sequentially. Each reviewer reads every file from the
+dynamic inventory and produces a structured findings list.
 
-**Reviewer A — GPT 5.4** (technical accuracy lens):
+**Constraints for both reviewers:**
 
-> You are a senior technical writer reviewing Azure infrastructure documentation.
-> Read every file listed in the inventory. For each file, check:
+- Max **30 findings** per reviewer (prioritise `must_fix` over nits)
+- Max **5 `must_fix`** per file
+- Line numbers are approximate — use the **section heading** as anchor if uncertain
+- Verify each finding's file path exists before including it
+- Verify image/asset references in `docs/assets/` resolve to real files
+- If approaching context limits after reading docs, prioritise: (1) broken links,
+  (2) agent/skill name accuracy, (3) cross-page consistency
+
+**Reviewer A** (data accuracy and structural correctness):
+
+> You are a QA triage engineer reviewing Azure infrastructure documentation.
+> Your signal-to-noise ratio must be > 3:1 — omit findings an average developer
+> wouldn't care about.
 >
-> 1. **Factual accuracy** — Do counts, version numbers, agent names, skill names,
->    and CLI commands match reality? Cross-reference `AGENTS.md`, `.github/agents/`,
->    `.github/skills/`, `package.json`, and `mkdocs.yml`.
+> Read every page from the dynamic inventory. Check:
+>
+> 1. **Factual accuracy** — Do agent names, skill names, MCP server names,
+>    and CLI commands match reality? Cross-reference the source-of-truth files
+>    listed above.
 > 2. **Internal consistency** — Do cross-page references agree? Are tables, lists,
->    and terminology consistent across files?
-> 3. **Completeness** — Are any agents, skills, instructions, or MCP servers missing?
->    Compare against the actual repo contents.
-> 4. **Broken links** — Flag any relative links that point to deleted or renamed files.
+>    and terminology consistent across files? Does the workflow step numbering
+>    (including Step 3.5 Governance) appear correctly everywhere?
+> 3. **Completeness** — Are any agents, subagents, skills, or MCP servers missing
+>    from docs but present on disk?
+> 4. **Broken links** — Flag any relative links or image references that point to
+>    deleted or renamed files.
 >
-> Return a JSON array of findings. Each finding:
+> Return a JSON array (max 30 items). Each finding:
 >
 > ```json
 > {
->   "file": "docs/...",
+>   "file": "docs/how-it-works/architecture.md",
 >   "line": 42,
->   "severity": "must_fix|should_fix|nit",
->   "category": "accuracy|consistency|completeness|broken_link",
->   "description": "...",
->   "suggestion": "..."
+>   "severity": "must_fix",
+>   "category": "accuracy",
+>   "description": "Agent table lists 15 top-level agents but disk has 16",
+>   "suggestion": "Update table row count and add 04g-Governance row"
 > }
 > ```
+>
+> Severity values: `must_fix` | `should_fix` | `nit` (use exactly these strings).
+> Category values: `accuracy` | `consistency` | `completeness` | `broken_link`.
+> One category per finding — if multi-faceted, split into separate findings.
 
-**Reviewer B — Claude Sonnet 4.6** (readability and UX lens):
+**Reviewer B** (readability, UX, and navigation):
 
 > You are a documentation UX specialist reviewing a developer docs site.
-> Read every file listed in the inventory. For each file, check:
+> Your goal is actionable UX improvements, not style nits. Aim for
+> 5–10 findings per file max.
+>
+> Read every page from the dynamic inventory. Check:
 >
 > 1. **Scannability** — Can a reader find what they need in <30 seconds?
 >    Are headings descriptive? Are long sections broken up?
@@ -74,61 +114,106 @@ produces a structured findings list.
 > 3. **Redundancy** — Is content duplicated across pages without purpose?
 >    Flag overlapping sections that could confuse readers.
 > 4. **Tone and clarity** — Is language direct, jargon-free where possible,
->    and consistent in voice?
+>    and consistent in voice? (Guides should use imperative "Do X";
+>    concepts should use declarative "X is...")
 > 5. **Navigation** — Do pages link forward to logical next steps?
 >    Are dead ends flagged?
 >
-> Return a JSON array of findings using the same schema as Reviewer A,
-> with categories: `scannability|onboarding|redundancy|clarity|navigation`.
+> Return a JSON array (max 30 items) using the same schema as Reviewer A.
+> Category values: `scannability` | `onboarding` | `redundancy` | `clarity` | `navigation`.
 
 ### Phase 2 — Adversarial review
 
-Run a third subagent pass using **Claude Sonnet 4.6** with an adversarial lens:
+Run a third subagent pass. **Pass Phase 1 findings as JSON context** at the start
+of the adversarial reviewer's prompt so it can see what was already found.
 
 > You are a hostile reviewer whose job is to find ways the documentation misleads,
 > confuses, or fails its readers. You have access to the findings from Reviewer A
-> and Reviewer B. Your job is NOT to repeat their findings. Instead:
+> and Reviewer B (provided as JSON arrays above). Your job is NOT to repeat their
+> findings verbatim. However, independently verify A and B's conclusions — if you
+> disagree with any finding, flag the disagreement explicitly. Then add adversarial
+> findings they missed.
 >
-> 1. **Untested assumptions** — What does the documentation assume the reader knows
->    that is never explained? (e.g., "dev container" without explaining what it is)
-> 2. **Happy path bias** — Where does documentation only cover the success case?
->    What happens when things go wrong?
-> 3. **Stale promises** — Are there claims about features, counts, or capabilities
->    that may have drifted from the actual codebase?
-> 4. **Missing audience** — Who is excluded by the current documentation?
->    (e.g., Terraform-only users, non-Azure users evaluating the project)
-> 5. **Contradictions** — Do any two pages contradict each other?
+> Focus on:
 >
-> Return a JSON array of findings with severity and category:
-> `assumption|happy_path|stale_promise|missing_audience|contradiction`.
+> 1. **Untested assumptions** — Knowledge the docs assume but never define.
+>    Only flag assumptions not explained _anywhere_ in the published docs
+>    (check Glossary and FAQ before flagging).
+> 2. **Happy path bias** — Step-by-step guides that never mention what happens
+>    when a step fails (e.g., no "if deployment fails, check logs" guidance).
+> 3. **Stale promises** — Claims that demonstrably conflict with current code.
+>    Verify against source-of-truth files listed above.
+> 4. **Missing audience** — Documented workflows that assume a specific IaC tool
+>    without mentioning the alternative track (e.g., all examples use Bicep but
+>    Terraform equivalents exist and are undocumented).
+> 5. **Contradictions** — Two pages that make conflicting claims about the same
+>    topic (e.g., different step counts, different agent names).
+>
+> Max **20 findings**. Return a JSON array with the same schema.
+> Category values: `assumption` | `happy_path` | `stale_promise` | `missing_audience` | `contradiction`.
+>
+> If either Phase 1 reviewer found zero findings in a domain, increase your
+> scrutiny in that domain — zero findings may indicate the reviewer missed issues,
+> not that none exist.
 
 ### Phase 3 — Reconciliation
 
-As the orchestrator (Claude Opus 4.6), consolidate all three finding sets:
+As the orchestrator, consolidate all three finding sets:
 
-1. **Deduplicate** — Merge findings that describe the same issue from different lenses.
-2. **Prioritise** — Rank by severity: `must_fix` > `should_fix` > `nit`.
-3. **Group by file** — Present findings grouped by file path, then by severity.
-4. **Action items** — For each `must_fix`, write a concrete one-line fix description.
-5. **Summary** — Count totals per severity and category. Call out the 3 most
-   impactful issues.
+1. **Validate** — For each finding, verify the file path exists and the line number
+   is within the file's actual line count. Remove any finding that references a
+   non-existent file (mark as `INVALID: file not found` in logs).
+
+2. **Deduplicate** — Merge findings that share the same `file` + overlapping line
+   range + identical `category`. Different categories on the same line = separate
+   findings. When merging, keep the most specific description and list all reviewer
+   sources (e.g., "Reviewer A + Adversarial").
+
+3. **Resolve contradictions** — If two reviewers disagree on the same finding
+   (e.g., A says accurate, Adversarial says stale), check the source-of-truth file.
+   If conflict persists, mark as "CONFLICT: needs manual triage".
+
+4. **Handle cross-file findings** — Issues that span multiple files (e.g., terminology
+   inconsistency across 5 pages) get their own section in the output rather than being
+   repeated per file.
+
+5. **Prioritise** — Rank by severity: `must_fix` > `should_fix` > `nit`.
+
+6. **Group** — Present per-file findings grouped by file path, then by severity.
 
 ## Output
 
-Present the reconciled report to the user as a markdown table per file, followed
-by the summary. Format:
+Present a **triage report** structured for fast human action:
 
 ```markdown
-### docs/{file}.md
+## Must-Fix (blockers) — N items
 
-| #   | Severity | Category | Description | Suggested Fix | Source     |
-| --- | -------- | -------- | ----------- | ------------- | ---------- |
-| 1   | must_fix | accuracy | ...         | ...           | Reviewer A |
-```
+| #   | File           | Line | Category | Description | Fix | Source     |
+| --- | -------------- | ---- | -------- | ----------- | --- | ---------- |
+| 1   | docs/agents.md | ~42  | accuracy | ...         | ... | Reviewer A |
 
-Then:
+## Should-Fix (next sprint) — top 10
 
-```markdown
+| #   | File             | Line | Category    | Description | Fix | Source      |
+| --- | ---------------- | ---- | ----------- | ----------- | --- | ----------- |
+| 1   | docs/workflow.md | ~12  | consistency | ...         | ... | Adversarial |
+
+## Cross-File Findings
+
+| #   | Files                                   | Category    | Description | Fix | Source                   |
+| --- | --------------------------------------- | ----------- | ----------- | --- | ------------------------ |
+| 1   | workflow.md, agents.md, architecture.md | consistency | ...         | ... | Reviewer A + Adversarial |
+
+## Nits — N items (collapsed)
+
+<details><summary>Expand nit-level findings</summary>
+
+| #   | File | Line | Category | Description | Source |
+| --- | ---- | ---- | -------- | ----------- | ------ |
+| 1   | ...  | ...  | ...      | ...         | ...    |
+
+</details>
+
 ## Summary
 
 | Severity   | Count |
@@ -137,11 +222,20 @@ Then:
 | should_fix | N     |
 | nit        | N     |
 
+**Verdict:** PASS | CONDITIONAL PASS | FAIL
+
+- FAIL = any `must_fix` findings remain
+- CONDITIONAL PASS = `must_fix` == 0, `should_fix` >= 15
+- PASS = `must_fix` == 0, `should_fix` < 15
+
 **Top 3 issues:**
 
 1. ...
 2. ...
 3. ...
 ```
+
+Valid `Source` values: `Reviewer A`, `Reviewer B`, `Adversarial`, or combined
+(e.g., `Reviewer A + Adversarial`).
 
 Do NOT edit any files. This is a read-only review. Present findings only.

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -14,6 +14,7 @@
     { "pattern": "^https://sloanreview\\.mit\\.edu" },
     { "pattern": "^https://trust\\.github\\.com" },
     { "pattern": "^https://azure\\.microsoft\\.com" },
+    { "pattern": "^https://openai\\.com" },
     { "pattern": "\\.(jpg|jpeg|png|gif|svg|webp)(\\?.*)?$" }
   ],
   "replacementPatterns": [

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing! Agentic InfraOps revolutionizes how
 Azure environments through coordinated AI agents.
 
 This file is the quick contributor entrypoint.
-For the agent orchestration workflow, see [Agent and Skill Workflow](workflow.md).
+For the agent orchestration workflow, see [Agent Architecture](how-it-works/agents.md).
 
 ## What We're Looking For
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -475,13 +475,14 @@ YAML is used in agent frontmatter (`.agent.md`), instruction frontmatter
 
 ## Numbers & Symbols
 
-### 7-Step Agentic Workflow
+### 8-Step Agentic Workflow
 
 The core Agentic InfraOps workflow: `requirements` → `architect` → Design Artifacts →
-IaC Plan → IaC Code → Deploy → Documentation. Steps 1-3 and 7 are shared;
-steps 4-6 diverge into **Bicep track** (`bicep-planner` → `bicep-codegen` → `bicep-deploy`)
-or **Terraform track** (`terraform-planner` → `terraform-codegen` → `terraform-deploy`).
-Each step produces artifacts in `agent-output/`.
+Governance → IaC Plan → IaC Code → Deploy → Documentation. Step 3.5 (Governance)
+runs between Design and IaC Plan. Steps 1–3 and 7 are shared; steps 4–6 diverge into
+**Bicep track** (`bicep-planner` → `bicep-codegen` → `bicep-deploy`) or **Terraform track**
+(`terraform-planner` → `terraform-codegen` → `terraform-deploy`). Each step produces
+artifacts in `agent-output/`.
 
 📁 **See**: [Workflow Guide](workflow.md)
 

--- a/docs/dev-containers.md
+++ b/docs/dev-containers.md
@@ -154,6 +154,12 @@ The container reads it automatically — no `gh auth login` required inside the 
 5. Rebuild the devcontainer: **F1 → Dev Containers: Rebuild Container**
 <!-- markdownlint-enable MD029 -->
 
+!!! warning "Why not shell exports?"
+
+    Running `export GH_TOKEN=...` inside the container does not persist across
+    rebuilds. VS Code User Settings inject the token via `terminal.integrated.env.linux`,
+    which the devcontainer forwards automatically.
+
 The devcontainer forwards `GH_TOKEN` from VS Code's environment automatically
 (`"GH_TOKEN": "${localEnv:GH_TOKEN}"` in `devcontainer.json`).
 
@@ -175,11 +181,10 @@ az --version && bicep --version && pwsh --version
 
 ## Alternative Docker Options
 
-!!! tip "Alternative: Rancher Desktop"
+!!! tip "Choose your Docker runtime before installing"
 
-    If Docker Desktop licensing is a concern, [Rancher Desktop](https://rancherdesktop.io/)
-    is a free alternative that works with the VS Code Dev Containers extension.
-    Choose "dockerd (moby)" as the runtime.
+    If Docker Desktop licensing is a concern, consider one of these free alternatives.
+    Choose your runtime **before** opening the dev container for the first time.
 
 ### Rancher Desktop (Free Docker Desktop Alternative)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,6 +2,8 @@
 
 Frequently asked questions about Agentic InfraOps.
 
+**Jump to:** [General](#general) · [IaC Tracks](#iac-tracks) · [Usage](#usage) · [Troubleshooting](#troubleshooting)
+
 ---
 
 ## General
@@ -131,7 +133,7 @@ Frequently asked questions about Agentic InfraOps.
     Yes — the [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/) is a
     hands-on, guided challenge where you build Azure infrastructure end-to-end using AI agents,
     from requirements to deployment. It includes structured exercises, guided prompts, and
-    reference solutions for each of the 7 workflow steps.
+    reference solutions for each of the 8 workflow steps.
 
 ---
 
@@ -170,7 +172,13 @@ Frequently asked questions about Agentic InfraOps.
     The workflow degrades gracefully. Steps 1-5 can proceed without MCP — agents skip
     real-time pricing lookups and use documented defaults. Only Step 2 cost estimation
     and Step 7 as-built cost updates depend directly on the Pricing MCP server.
-    Governance discovery (Step 4) uses Azure CLI, not MCP.
+    Governance discovery (Step 3.5) uses Azure REST API, not MCP.
+
+!!! warning "Step 6 (Deploy) requires Azure credentials"
+
+    If you attempt deployment without an active Azure subscription and `az login`,
+    the deploy agent will fail with an authentication error.
+    See [Troubleshooting](troubleshooting.md) for recovery steps.
 
 ---
 

--- a/docs/how-it-works/agents.md
+++ b/docs/how-it-works/agents.md
@@ -129,6 +129,12 @@ This achieves 40–70% input reduction for heavy artefacts. After each review pa
 only the `compact_for_parent` string is carried forward (not the full JSON findings),
 preventing context bloat across multi-pass reviews.
 
+!!! tip "If a challenger review hangs"
+
+    If a review takes >10 minutes with no output, restart the chat session and
+    resume from the failed gate. Use `00-session-state.json` to verify the last
+    completed step.
+
 **New Challenger Checklists**: Two mandatory checklist categories were added:
 
 - **Cost Monitoring**: Budget resource, forecast alerts at 80/100/120%, anomaly detection.
@@ -157,4 +163,4 @@ This enables resume from any gate without needing to re-read all prior artefacts
     - [Core Concepts](four-pillars.md) — the four knowledge layers (agents, skills, instructions, registries)
     - [Skills & Instructions](skills-and-instructions.md) — progressive skill loading and glob-based enforcement
     - [Workflow Engine & Quality](workflow-engine.md) — DAG model, approval gates, circuit breakers
-    - [MCP Integration](mcp-integration.md) — the four MCP servers and their tool catalogs
+    - [MCP Integration](mcp-integration.md) — MCP servers and their tool catalogs

--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -106,9 +106,9 @@ decision context. The new session resumes from the checkpoint by reading the sta
 | Utility        | GPT-4o-mini   | Session state updates, lightweight tasks         |
 
 **Subagent Integration Matrix**: The full mapping of which subagents are invoked by
-which parent agents is externalised to
-[`.github/skills/workflow-engine/references/subagent-integration.md`](../../.github/skills/workflow-engine/references/subagent-integration.md) to keep the
-Conductor body under the 350-line limit.
+which parent agents is externalised to the
+[subagent-integration reference](../../.github/skills/workflow-engine/references/subagent-integration.md)
+to keep the Conductor body under the 350-line limit.
 
 ## :material-source-fork: Dual IaC Tracks
 

--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -4,7 +4,7 @@ toc_depth: 3
 
 # :material-transit-connection-variant: System Architecture Overview
 
-## :material-format-list-numbered: The 7-Step Workflow
+## :material-format-list-numbered: The 8-Step Workflow
 
 The system follows a strict sequential workflow with mandatory human approval gates
 between critical phases:
@@ -50,16 +50,16 @@ flowchart LR
     S1 --> G1 --> S2 --> G2 --> S3 --> S35 --> G25 --> S4 --> G3 --> S5 --> G4 --> S6 --> G5 --> S7
 ```
 
-| Step | Phase        | Agent                              | Output                                   | Review            |
-| ---- | ------------ | ---------------------------------- | ---------------------------------------- | ----------------- |
-| 1    | Requirements | 02-Requirements                    | `01-requirements.md`                     | 1 challenger pass |
-| 2    | Architecture | 03-Architect                       | `02-architecture-assessment.md` + cost   | 3+1 passes        |
-| 3    | Design (opt) | 04-Design                          | `03-des-*.{py,png,md}`                   | —                 |
-| 3.5  | Governance   | 04g-Governance                     | `04-governance-constraints.md/.json`     | —                 |
-| 4    | IaC Plan     | 05b-Bicep Planner / 05t-TF Planner | `04-implementation-plan.md`              | 1+3 passes        |
-| 5    | IaC Code     | 06b-Bicep CodeGen / 06t-TF CodeGen | `infra/bicep/` or `infra/terraform/`     | 3 passes          |
-| 6    | Deploy       | 07b-Bicep Deploy / 07t-TF Deploy   | `06-deployment-summary.md`               | 1 pass            |
-| 7    | As-Built     | 08-As-Built                        | `07-*.md` documentation suite            | —                 |
+| Step | Phase        | Agent                              | Output                                 | Review            |
+| ---- | ------------ | ---------------------------------- | -------------------------------------- | ----------------- |
+| 1    | Requirements | 02-Requirements                    | `01-requirements.md`                   | 1 challenger pass |
+| 2    | Architecture | 03-Architect                       | `02-architecture-assessment.md` + cost | 3+1 passes        |
+| 3    | Design (opt) | 04-Design                          | `03-des-*.{py,png,md}`                 | —                 |
+| 3.5  | Governance   | 04g-Governance                     | `04-governance-constraints.md/.json`   | —                 |
+| 4    | IaC Plan     | 05b-Bicep Planner / 05t-TF Planner | `04-implementation-plan.md`            | 1+3 passes        |
+| 5    | IaC Code     | 06b-Bicep CodeGen / 06t-TF CodeGen | `infra/bicep/` or `infra/terraform/`   | 3 passes          |
+| 6    | Deploy       | 07b-Bicep Deploy / 07t-TF Deploy   | `06-deployment-summary.md`             | 1 pass            |
+| 7    | As-Built     | 08-As-Built                        | `07-*.md` documentation suite          | —                 |
 
 ## :material-music: The Conductor Pattern
 
@@ -100,14 +100,14 @@ decision context. The new session resumes from the checkpoint by reading the sta
 
 | Tier           | Model         | Used By                                          |
 | -------------- | ------------- | ------------------------------------------------ |
-| Primary        | Claude Opus   | Conductor, Steps 1–7 agents                      |
+| Primary        | Claude Opus   | Conductor, all workflow step agents              |
 | Review         | Claude Sonnet | Challenger reviews, code reviews (A/B validated) |
 | Heavy API Work | GPT Codex     | Governance discovery (batch REST API calls)      |
 | Utility        | GPT-4o-mini   | Session state updates, lightweight tasks         |
 
 **Subagent Integration Matrix**: The full mapping of which subagents are invoked by
 which parent agents is externalised to
-`.github/skills/workflow-engine/references/subagent-integration.md` to keep the
+[`.github/skills/workflow-engine/references/subagent-integration.md`](../../.github/skills/workflow-engine/references/subagent-integration.md) to keep the
 Conductor body under the 350-line limit.
 
 ## :material-source-fork: Dual IaC Tracks
@@ -117,7 +117,8 @@ Conductor body under the 350-line limit.
   alt="Railway tracks diverging representing dual IaC tracks"></div><br/>
 
 Steps 1–3 (Requirements, Architecture, Design) are shared across both infrastructure
-tracks. At Step 4, the workflow diverges based on the `iac_tool` field in the requirements
+tracks. Step 3.5 (Governance) is also shared and mandatory. At Step 4, the workflow
+diverges based on the `iac_tool` field in the requirements
 document:
 
 ```mermaid
@@ -163,4 +164,4 @@ flowchart TD
     - [Core Concepts](four-pillars.md) — agents, skills, instructions, and configuration registries
     - [Agent Architecture](agents.md) — 16 top-level agents, 11 subagents, Challenger pattern
     - [Workflow Engine & Quality](workflow-engine.md) — DAG model, session state, circuit breakers
-    - [MCP Integration](mcp-integration.md) — four MCP servers and tool catalogs
+    - [MCP Integration](mcp-integration.md) — MCP servers and tool catalogs

--- a/docs/how-it-works/four-pillars.md
+++ b/docs/how-it-works/four-pillars.md
@@ -39,7 +39,8 @@ directives. The `SKILL.md` file provides a compact overview (under 500 lines), a
 reference material is stored in subdirectories, loaded only when the agent's task demands it.
 
 **Key constraint**: Skills implement progressive disclosure — agents start with the overview
-and drill into `references/` only when needed.
+and drill into `references/` only when needed. This preserves context window space for
+task-specific knowledge.
 
 ## :material-file-document-outline: 3. Instructions
 
@@ -119,7 +120,7 @@ and the VS Code runtime. Tools give agents real-time access to external systems:
   `agent-output/{project}/`. The next agent reads those files as input — there is no
   direct message passing between agents.
 
-This project integrates four MCP servers:
+This project integrates three MCP servers (in `.vscode/mcp.json`) plus the Azure MCP extension:
 
 | Server            | Purpose                            | Transport          |
 | ----------------- | ---------------------------------- | ------------------ |
@@ -137,4 +138,4 @@ This project integrates four MCP servers:
     - [Agent Architecture](agents.md) — 16 top-level agents, 11 subagents, the Challenger pattern
     - [Skills & Instructions](skills-and-instructions.md) — progressive loading, glob-based enforcement
     - [Workflow Engine & Quality](workflow-engine.md) — DAG model, approval gates, validators
-    - [MCP Integration](mcp-integration.md) — four MCP servers and their tool catalogs
+    - [MCP Integration](mcp-integration.md) — MCP servers and their tool catalogs

--- a/docs/how-it-works/index.md
+++ b/docs/how-it-works/index.md
@@ -76,7 +76,7 @@ are enforced as first-class concerns across all generated infrastructure.
 
   ***
 
-  Four MCP servers: GitHub, Azure, Pricing, and Terraform Registry.
+  Three MCP servers plus one VS Code extension: GitHub, Azure Pricing, Terraform Registry, and Azure MCP (extension).
 
   [:octicons-arrow-right-24: MCP servers](mcp-integration.md)
 
@@ -210,7 +210,7 @@ artefact files in `agent-output/{project}/` and the machine-readable
 **Right-sized task decomposition.** Ralph insists that each PRD item must be
 small enough to complete within a single context window — "Add a database
 column" not "Build the entire dashboard." This project enforces the same
-principle at a different scale: each of the 7 workflow steps is scoped to a
+principle at a different scale: each of the 8 workflow steps is scoped to a
 single well-defined output (one requirements doc, one architecture assessment,
 one implementation plan), and subagents are further decomposed to atomic
 validation or review tasks.

--- a/docs/how-it-works/mcp-integration.md
+++ b/docs/how-it-works/mcp-integration.md
@@ -6,13 +6,15 @@ toc_depth: 3
 
 The Model Context Protocol (MCP) is an open standard that allows AI agents to
 discover and invoke external tools through a uniform JSON-RPC interface.
-This project integrates four MCP servers, each providing specialised
-capabilities that agents invoke at runtime.
+This project integrates three MCP servers (declared in `.vscode/mcp.json`) plus the
+Azure MCP Server (a VS Code extension), each providing specialised capabilities that
+agents invoke at runtime.
 
 ## :material-lan: MCP Architecture
 
-All MCP servers are declared in `.vscode/mcp.json` and start automatically
-when VS Code invokes them. Agents never call cloud APIs directly — they
+Three MCP servers are declared in `.vscode/mcp.json` and start automatically
+when VS Code invokes them. The Azure MCP Server runs as a VS Code extension
+(`ms-azuretools.vscode-azure-mcp-server`) and uses `az login` credentials. Agents never call cloud APIs directly — they
 call MCP tools, which handle authentication, caching, pagination, retries,
 and response formatting.
 
@@ -123,6 +125,13 @@ The server includes a 256-entry TTL cache (5-minute pricing, 24-hour
 retirement data, 1-hour spot data), ~95 user-friendly service name
 mappings (e.g. `"vm"` → `"Virtual Machines"`), and structured error
 codes for consistent agent error handling.
+
+!!! note "Pricing accuracy"
+
+    Cached prices may not reflect real-time promotional discounts, reserved instance
+    pricing, or recent regional changes. Always validate final estimates in the
+    [Azure Pricing Calculator](https://azure.microsoft.com/pricing/calculator/)
+    before committing budget.
 
 Primarily scoped to the **Architect** agent (Step 2), the
 **cost-estimate-subagent**, and the **As-Built** agent (Step 7).

--- a/docs/how-it-works/workflow-engine.md
+++ b/docs/how-it-works/workflow-engine.md
@@ -73,6 +73,12 @@ Each node has a type (`agent-step`, `gate`, `subagent-fan-out`, `validation`), a
 edge has a condition (`on_complete`, `on_skip`, `on_fail`). Conditional routing at IaC
 nodes is governed by the `decisions.iac_tool` field.
 
+!!! info "Read-only workflow graph"
+
+    The workflow DAG is auto-loaded by the Conductor. Users do not edit
+    `workflow-graph.json` directly. To customise the workflow, modify agent
+    definitions or skills instead.
+
 ### Gates and Approval Points
 
 Five mandatory gates require explicit human confirmation before the workflow advances:
@@ -240,4 +246,4 @@ and timeout. They run automatically — agents do not invoke them explicitly.
     - [System Architecture](architecture.md) — the 8-step workflow, Conductor pattern, dual IaC tracks
     - [Core Concepts](four-pillars.md) — agents, skills, instructions, and configuration registries
     - [Agent Architecture](agents.md) — handoffs, the Challenger pattern, context shredding
-    - [MCP Integration](mcp-integration.md) — four MCP servers and how agents invoke tools
+    - [MCP Integration](mcp-integration.md) — MCP servers and how agents invoke tools

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,13 +159,13 @@ sequenceDiagram
 
 ## :material-chart-box-outline: Key Facts
 
-|                 |                                       |
-| --------------- | ------------------------------------- |
-| **Agents**      | 16 primary + 11 subagents             |
-| **Skills**      | Reusable domain knowledge modules     |
-| **IaC Tracks**  | Bicep and Terraform (dual-track)      |
-| **MCP Servers** | Azure, Pricing, Terraform, GitHub     |
-| **Workflow**    | 8 steps with mandatory approval gates |
+|                 |                                                          |
+| --------------- | -------------------------------------------------------- |
+| **Agents**      | 16 top-level + 11 subagents                              |
+| **Skills**      | Reusable domain knowledge modules                        |
+| **IaC Tracks**  | Bicep and Terraform (dual-track)                         |
+| **MCP Servers** | GitHub, Azure Pricing, Terraform + Azure MCP (extension) |
+| **Workflow**    | 8 steps with mandatory approval gates                    |
 
 ## :material-star-outline: Highlights
 

--- a/docs/prompt-guide/best-practices.md
+++ b/docs/prompt-guide/best-practices.md
@@ -123,13 +123,13 @@ Prompt 4: Make the address space configurable via parameters
 
     Avoid these patterns — they lead to incomplete, generic, or incorrect AI output.
 
-| Anti-Pattern             | Problem                 | Better Approach                       |
-| ------------------------ | ----------------------- | ------------------------------------- |
-| "Generate everything"    | Output too broad        | Break into small requests             |
-| Accepting without review | Bugs, security issues   | Always validate and test              |
-| Ignoring context         | Generic suggestions     | Open relevant files, use `@workspace` |
-| One-shot complex prompts | Incomplete output       | Iterate with follow-ups               |
-| Not providing examples   | Inconsistent formatting | Show the pattern you want             |
+| Anti-Pattern             | Problem                 | Better Approach                                                                 |
+| ------------------------ | ----------------------- | ------------------------------------------------------------------------------- |
+| "Generate everything"    | Output too broad        | Break into one module per prompt: VNet, then NSGs, then diagnostics             |
+| Accepting without review | Bugs, security issues   | Always run `bicep lint` / `terraform validate` and review for hardcoded secrets |
+| Ignoring context         | Generic suggestions     | Open relevant files first, use `@workspace` and `#file:` references             |
+| One-shot complex prompts | Incomplete output       | Iterate: start with skeleton, add security, add monitoring, add parameters      |
+| Not providing examples   | Inconsistent formatting | Show the naming pattern or module structure you want the agent to follow        |
 
 ## :material-check-decagram-outline: Always Validate AI Output
 

--- a/docs/prompt-guide/index.md
+++ b/docs/prompt-guide/index.md
@@ -34,7 +34,7 @@ infrastructure.
 
   ***
 
-  Ready-to-use prompts for all 7 workflow steps plus standalone agents.
+  Ready-to-use prompts for all 8 workflow steps plus standalone agents.
 
   [:octicons-arrow-right-24: Workflow prompts](workflow-prompts.md)
 
@@ -103,33 +103,31 @@ Reusable `.prompt.md` files in `.github/prompts/` provide one-click access
 to pre-configured agent workflows. In VS Code, type `/` in Copilot Chat
 to see available prompts.
 
-!!! warning "Planned prompt files"
-
-    The prompt files listed below are planned additions. Currently, only
-    `doc-gardening`, `git-commit-push`, and `plan-docsPeerReview` exist
-    in `.github/prompts/`. The remaining prompts will be added in a future release.
-
 #### Core Workflow Prompts
 
-| Prompt File           | Agent              | Step | Purpose                                     |
-| --------------------- | ------------------ | ---- | ------------------------------------------- |
-| `run-conductor`       | InfraOps Conductor | All  | End-to-end 8-step orchestration             |
-| `plan-requirements`   | Requirements       | 1    | Business-first requirements discovery       |
-| `assess-architecture` | Architect          | 2    | WAF assessment with cost estimates          |
-| `design-diagram`      | Design             | 3    | Python architecture diagram generation      |
-| `design-adr`          | Design             | 3    | Architecture Decision Record creation       |
-| `plan-bicep`          | Bicep Planner      | 4b   | Governance discovery and Bicep planning     |
-| `plan-terraform`      | Terraform Planner  | 4t   | Governance discovery and Terraform planning |
-| `generate-bicep`      | Bicep CodeGen      | 5b   | AVM-first Bicep template generation         |
-| `generate-terraform`  | Terraform CodeGen  | 5t   | AVM-TF Terraform config generation          |
-| `deploy`              | Bicep Deploy       | 6b   | What-if analysis and Bicep deployment       |
-| `deploy-terraform`    | Terraform Deploy   | 6t   | Terraform plan preview and apply            |
-| `generate-docs`       | As-Built           | 7    | As-built documentation suite                |
-| `diagnose-resources`  | Diagnose           | —    | Resource health diagnostics                 |
+| Prompt File             | Agent              | Step | Purpose                                     |
+| ----------------------- | ------------------ | ---- | ------------------------------------------- |
+| `01-conductor`          | InfraOps Conductor | All  | End-to-end 8-step orchestration             |
+| `02-requirements`       | Requirements       | 1    | Business-first requirements discovery       |
+| `03-architect`          | Architect          | 2    | WAF assessment with cost estimates          |
+| `04-design`             | Design             | 3    | Python architecture diagrams and ADRs       |
+| `04g-governance`        | Governance         | 3.5  | Azure Policy governance discovery           |
+| `05b-bicep-planner`     | Bicep Planner      | 4b   | Governance discovery and Bicep planning     |
+| `05t-terraform-planner` | Terraform Planner  | 4t   | Governance discovery and Terraform planning |
+| `06b-bicep-codegen`     | Bicep CodeGen      | 5b   | AVM-first Bicep template generation         |
+| `06t-terraform-codegen` | Terraform CodeGen  | 5t   | AVM-TF Terraform config generation          |
+| `07b-bicep-deploy`      | Bicep Deploy       | 6b   | What-if analysis and Bicep deployment       |
+| `07t-terraform-deploy`  | Terraform Deploy   | 6t   | Terraform plan preview and apply            |
+| `08-as-built`           | As-Built           | 7    | As-built documentation suite                |
+| `diagnose-resource`     | Diagnose           | —    | Resource health diagnostics                 |
 
-#### Demo Prompts
+#### Utility Prompts
 
-| Prompt File                 | Agent              | Purpose                                      |
-| --------------------------- | ------------------ | -------------------------------------------- |
-| `conductor-demo`            | InfraOps Conductor | Full workflow demo (Static Web App scenario) |
-| `plan-req-demo-interactive` | Requirements       | Interactive EU ecommerce migration demo      |
+| Prompt File           | Purpose                                      |
+| --------------------- | -------------------------------------------- |
+| `git-commit-push`     | Diff-aware conventional commit and push      |
+| `doc-gardening`       | Documentation maintenance and freshness      |
+| `plan-docsPeerReview` | Multi-pass documentation peer review         |
+| `challenger-review`   | Standalone adversarial review of an artifact |
+| `context-audit`       | Agent context window utilization audit       |
+| `resume-workflow`     | Resume an interrupted workflow session       |

--- a/docs/prompt-guide/reference.md
+++ b/docs/prompt-guide/reference.md
@@ -12,7 +12,8 @@ directly in prompts.
 ### azure-defaults
 
 Provides regions, tags, naming conventions, AVM module references, and
-security baselines. Agents read this skill before every task.
+security baselines. This is the foundational skill — agents read it before
+every task.
 
 ```text
 @workspace What are the default required tags from azure-defaults?
@@ -101,7 +102,7 @@ and Log Analytics best practices.
 ### azure-artifacts
 
 Artifact template structures, H2 compliance rules, and documentation
-styling for all agent outputs (Steps 1-7).
+styling for all agent outputs (all steps).
 
 ```text
 @workspace What H2 headings are required in the implementation plan template?
@@ -167,6 +168,14 @@ Resume the workflow from step 4 using the existing session state.
 
 Machine-readable workflow DAG for the 8-step pipeline. Defines node
 types, edge conditions, gates, and fan-out patterns.
+
+## :material-account-cog-outline: Subagents
+
+!!! info "Not user-invocable"
+
+    Subagents are delegated to automatically by parent agents. You cannot
+    select them from the agent picker (`Ctrl+Shift+A`). See
+    [Workflow Prompts](workflow-prompts.md) for end-user scenarios.
 
 ```text
 @workspace Show the workflow graph edges and gate conditions.

--- a/docs/prompt-guide/workflow-prompts.md
+++ b/docs/prompt-guide/workflow-prompts.md
@@ -4,7 +4,7 @@ toc_depth: 2
 
 # :material-format-list-numbered: Workflow Prompts
 
-The Agentic InfraOps workflow follows seven steps. Use the **InfraOps Conductor** to
+The Agentic InfraOps workflow follows eight steps (including Step 3.5 Governance). Use the **InfraOps Conductor** to
 run all steps end-to-end, or invoke individual agents directly.
 
 ## :material-play-circle: End-to-End (Conductor)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -159,7 +159,10 @@ Invoke agents directly for specific tasks:
 ## :material-chart-timeline-variant: Step 7: Follow the Workflow
 
 The agents work in sequence with handoffs. Steps 1-3.5 and 7 are shared;
-steps 4-6 route to **Bicep** or **Terraform** agents based on your `iac_tool` selection.
+steps 4-6 route to **Bicep** or **Terraform** agents based on your `iac_tool` selection
+in Step 1. During requirements gathering, the Requirements agent asks which IaC tool
+you prefer — this choice determines which planning, code generation, and deployment
+agents the Conductor invokes.
 
 Each agent has a thematic codename for easy reference in documentation and prompts.
 
@@ -182,6 +185,13 @@ Each agent has a thematic codename for easy reference in documentation and promp
 - ⛔ **Gate 3**: After planning (Step 4) — approve implementation plan
 - ⛔ **Gate 4**: After validation (Step 5) — approve preflight results
 - ⛔ **Gate 5**: After deployment (Step 6) — verify resources
+
+!!! tip "If a gate rejects your proposal"
+
+    If the Challenger or an approval gate produces `must_fix` findings, return to the
+    previous step, update your approach based on the feedback, and re-run. The Conductor
+    will re-execute the step and re-trigger the gate. Use the artifact files in
+    `agent-output/{project}/` to understand what was flagged.
 
 ## :material-folder-check-outline: What You've Created
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -129,6 +129,11 @@ Responses are instant, no terminal commands execute, no files are created.
    - Right-click in Chat view → "Diagnostics"
    - Check all agents are loaded correctly
 
+5. **If the session was interrupted** (no new output, truncated response):
+   - Check `agent-output/{project}/00-session-state.json` for the last completed step
+   - Restart the Conductor with: _"Resume the workflow from step X"_
+   - See [Workflow Engine](how-it-works/workflow-engine.md) for session state details
+
 **Note**: Workspace settings (`.vscode/settings.json`) may not be sufficient
 for experimental features. User settings take precedence.
 
@@ -429,7 +434,7 @@ handoffs:
 Ensure target agent exists:
 
 ```bash
-ls .github/agents/architect.agent.md
+ls .github/agents/03-architect.agent.md
 ```
 
 ## Diagnostic Commands

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -219,9 +219,9 @@ graph TB
 | ---------------------- | ---------- | --------------------------------------- | -------------------- |
 | **InfraOps Conductor** | 🎼 Maestro | Master orchestrator for 8-step workflow | Claude Opus (latest) |
 
-### Core Agents (7 Steps)
+### Core Agents (8 Steps)
 
-Steps 1-3 and 7 are shared. Steps 4-6 have Bicep and Terraform variants.
+Steps 1-3.5 and 7 are shared. Steps 4-6 have Bicep and Terraform variants.
 
 | Step | Agent              | Codename      | Role                                 | Artifact                                             |
 | ---- | ------------------ | ------------- | ------------------------------------ | ---------------------------------------------------- |


### PR DESCRIPTION
## Summary

Applies all findings from a full 4-phase docs peer review (3 rounds of fixes + 2 adversarial re-reviews). Validated with `markdownlint` (0 errors) and grep sweeps.

## Changes (32 edits across 19 files)

### Accuracy fixes
- Fix all stale `7-step`/`7 workflow steps` references — now correctly say **8-step workflow**
- Fix MCP server count (`four MCP servers` → three servers + VS Code extension)
- Replace placeholder prompt-guide table with real **19-prompt inventory** (correct filenames)
- Fix broken agent filename reference (`architect.agent.md` → `03-architect.agent.md`)
- Fix governance step reference (Step 4 → Step 3.5, Azure CLI → Azure REST API)
- Fix CONTRIBUTING misleading workflow link → correct agents architecture page

### Onboarding / UX improvements
- Add `iac_tool` field explanation and gate-rejection recovery tip to quickstart
- Add session resume guidance for interrupted Conductor sessions (troubleshooting)
- Add Azure credential warning callout for Step 6 deploy (FAQ)
- Add subagent ` source /workspaces/azure-agentic-infraops/.venv/bin/activate! info "Not user-invocable"` warning block to skills reference
- Add `read-only DAG` note and Challenger timeout recovery tip
- Add `Why not shell exports?` callout in dev-containers
- Replace anti-pattern 'Better Approach' column with concrete task examples

### Glossary / reference alignment
- Update GLOSSARY 8-Step definition to include Governance step
- Clarify dual IaC track description with Step 3.5 Governance
- Label `azure-defaults` as foundational skill in reference page
- Update `azure-artifacts` skill scope from 'Steps 1-7' → 'all steps'

## Validation
- `npx markdownlint-cli2 'docs/**/*.md'` → `Summary: 0 error(s)` (213 files)
- Grep sweep for stale step counts and MCP counts: clean
- Lefthook pre-push: `diff-based-check` passed