### PR TITLE
feat(scripts): add init-from-template helper for accelerator forks

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "validate:skill-affinity": "node scripts/validate-skill-affinity.mjs",
     "validate:skill-digests": "node scripts/validate-skill-digests.mjs",
     "validate:docs-sync": "node scripts/validate-docs-sync.mjs",
+    "init": "node scripts/init-from-template.mjs",
     "validate:_node": "run-p lint:artifact-templates lint:h2-sync lint:version-sync lint:deprecated-refs lint:mcp-config lint:agent-frontmatter lint:skills-format lint:instruction-frontmatter lint:governance-refs validate:instruction-refs validate:session-state validate:session-lock validate:workflow-graph validate:agent-registry validate:skill-affinity validate:skill-digests lint:json lint:skill-size lint:agent-body-size lint:glob-audit lint:skill-references lint:orphaned-content lint:docs-freshness",
     "validate:_external": "run-p lint:md lint:python lint:terraform-fmt validate:terraform",
     "validate:all": "run-p --continue-on-error validate:_node validate:_external && echo '✅ All validations passed'"

--- a/scripts/init-from-template.mjs
+++ b/scripts/init-from-template.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Replaces all accelerator template repository references with this repository's URL.
+ * Run once after creating a new repository from the accelerator template.
+ * Auto-detects the new owner/repo from the git remote.
+ *
+ * @example
+ * npm run init
+ * npm run init -- --dry-run
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const TEMPLATE_OWNER = "jonathan-vella";
+const TEMPLATE_REPO = "azure-agentic-infraops-accelerator";
+const TEMPLATE_SLUG = `${TEMPLATE_OWNER}/${TEMPLATE_REPO}`;
+const TEMPLATE_URL = `https://github.com/${TEMPLATE_SLUG}`;
+
+const SKIP_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "site",
+  ".venv",
+  "__pycache__",
+]);
+const SKIP_EXTS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".ico",
+  ".svg",
+  ".woff",
+  ".woff2",
+  ".zip",
+  ".gz",
+]);
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run") || args.includes("--dry");
+const showHelp = args.includes("--help") || args.includes("-h");
+
+if (showHelp) {
+  console.log(`
+Usage: npm run init [-- --dry-run]
+
+Replaces all references to the accelerator template repository
+  ${TEMPLATE_URL}
+with this repository's URL, auto-detected from the git remote.
+
+Run this once after creating a new repository from the accelerator template.
+
+Options:
+  --dry-run   Preview which files would be changed without modifying them
+  --help, -h  Show this help message
+`);
+  process.exit(0);
+}
+
+/** Parse a GitHub HTTPS or SSH remote URL into an "owner/repo" slug. */
+function parseSlug(remoteUrl) {
+  const https = remoteUrl.match(
+    /^https:\/\/github\.com\/([^/]+)\/([^/.]+?)(\.git)?$/,
+  );
+  if (https) return `${https[1]}/${https[2]}`;
+  const ssh = remoteUrl.match(/^git@github\.com:([^/]+)\/([^/.]+?)(\.git)?$/);
+  if (ssh) return `${ssh[1]}/${ssh[2]}`;
+  return null;
+}
+
+/** Recursively collect files that contain the template slug (text files only). */
+function findAffected(dir, results = []) {
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      if (!SKIP_DIRS.has(entry)) findAffected(fullPath, results);
+    } else {
+      const ext = entry.includes(".") ? `.${entry.split(".").pop()}` : "";
+      if (SKIP_EXTS.has(ext.toLowerCase())) continue;
+      try {
+        const content = readFileSync(fullPath, "utf8");
+        if (content.includes(TEMPLATE_SLUG))
+          results.push({ fullPath, content });
+      } catch {
+        // Binary or unreadable — skip silently
+      }
+    }
+  }
+  return results;
+}
+
+// --- main ---
+
+console.log("🔍 Detecting repository remote URL...");
+
+let remoteUrl;
+try {
+  remoteUrl = execSync("git remote get-url origin", {
+    encoding: "utf8",
+  }).trim();
+} catch {
+  console.error(
+    "❌ Could not detect git remote 'origin'. Are you inside a git repository?",
+  );
+  process.exit(1);
+}
+
+const newSlug = parseSlug(remoteUrl);
+if (!newSlug) {
+  console.error(`❌ Cannot parse a GitHub slug from remote URL: ${remoteUrl}`);
+  console.error(
+    "   Expected: https://github.com/owner/repo  or  git@github.com:owner/repo",
+  );
+  process.exit(1);
+}
+
+const newUrl = `https://github.com/${newSlug}`;
+
+if (newSlug === TEMPLATE_SLUG) {
+  console.log(
+    "ℹ️  Remote matches the template repository — nothing to replace.",
+  );
+  process.exit(0);
+}
+
+console.log(`📋 Template: ${TEMPLATE_URL}`);
+console.log(`🎯 Target:   ${newUrl}`);
+console.log("");
+
+const affected = findAffected(".");
+
+if (affected.length === 0) {
+  console.log(
+    "✅ No files contain template references. Repository already initialized.",
+  );
+  process.exit(0);
+}
+
+console.log(`${affected.length} file(s) with template references:`);
+for (const { fullPath } of affected) {
+  console.log(`  📄 ${relative(".", fullPath)}`);
+}
+console.log("");
+
+if (dryRun) {
+  console.log("⚠️  Dry-run mode — no files modified.");
+  process.exit(0);
+}
+
+let count = 0;
+for (const { fullPath, content } of affected) {
+  const updated = content.replaceAll(TEMPLATE_SLUG, newSlug);
+  writeFileSync(fullPath, updated, "utf8");
+  console.log(`  ✅ Updated: ${relative(".", fullPath)}`);
+  count++;
+}
+
+console.log("");
+console.log(`✅ Done — updated ${count} file(s).`);
+console.log(`   ${TEMPLATE_URL}`);
+console.log(`   → ${newUrl}`);
+console.log("");
+console.log("💡 Next steps:");
+console.log("   1. Review changes:  git diff");
+console.log(
+  "   2. Commit:          git add -A && git commit -m 'chore: initialize from template'",
+);

--- a/scripts/init-from-template.sh
+++ b/scripts/init-from-template.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# init-from-template.sh
+# Replaces all accelerator template repository references with this repository's URL.
+# Run once after creating a new repository from the accelerator template.
+#
+# @example
+#   bash scripts/init-from-template.sh
+#   bash scripts/init-from-template.sh --dry-run
+set -euo pipefail
+
+readonly TEMPLATE_OWNER="jonathan-vella"
+readonly TEMPLATE_REPO="azure-agentic-infraops-accelerator"
+readonly TEMPLATE_SLUG="${TEMPLATE_OWNER}/${TEMPLATE_REPO}"
+readonly TEMPLATE_URL="https://github.com/${TEMPLATE_SLUG}"
+
+DRY_RUN=false
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [--dry-run]
+
+Replaces all references to the accelerator template repository
+  ${TEMPLATE_URL}
+with this repository's URL, auto-detected from the git remote.
+
+Run this once after creating a new repository from the accelerator template.
+
+Options:
+  --dry-run   Preview which files would be changed without modifying them
+  -h, --help  Show this help message
+
+USAGE
+}
+
+# Parse a GitHub remote URL (HTTPS or SSH) into owner/repo slug.
+# Outputs the slug on stdout; outputs empty string if unparsable.
+parse_remote_slug() {
+  local remote_url="$1"
+  # HTTPS: https://github.com/owner/repo[.git]
+  if [[ "$remote_url" =~ ^https://github\.com/([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return
+  fi
+  # SSH: git@github.com:owner/repo[.git]
+  if [[ "$remote_url" =~ ^git@github\.com:([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return
+  fi
+  echo ""
+}
+
+# List text files that reference the template slug (skips binary files).
+find_affected_files() {
+  grep -rlI "${TEMPLATE_SLUG}" \
+    --exclude-dir=.git \
+    --exclude-dir=node_modules \
+    --exclude-dir=site \
+    --exclude-dir=.venv \
+    --exclude='*.png' \
+    --exclude='*.jpg' \
+    --exclude='*.jpeg' \
+    --exclude='*.gif' \
+    --exclude='*.ico' \
+    --exclude='*.svg' \
+    --exclude='*.woff' \
+    --exclude='*.woff2' \
+    --exclude='*.zip' \
+    . 2>/dev/null || true
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --dry-run) DRY_RUN=true; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) echo "❌ Unknown option: $1"; usage; exit 1 ;;
+    esac
+  done
+
+  echo "🔍 Detecting repository remote URL..."
+  local remote_url
+  remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+
+  if [[ -z "$remote_url" ]]; then
+    echo "❌ Could not detect git remote 'origin'. Are you inside a git repository?"
+    exit 1
+  fi
+
+  local new_slug
+  new_slug=$(parse_remote_slug "$remote_url")
+
+  if [[ -z "$new_slug" ]]; then
+    echo "❌ Cannot parse a GitHub slug from remote URL: ${remote_url}"
+    echo "   Expected format: https://github.com/owner/repo"
+    echo "                or: git@github.com:owner/repo"
+    exit 1
+  fi
+
+  local new_url="https://github.com/${new_slug}"
+
+  if [[ "$new_slug" == "$TEMPLATE_SLUG" ]]; then
+    echo "ℹ️  Remote matches the template repository — nothing to replace."
+    exit 0
+  fi
+
+  echo "📋 Template: ${TEMPLATE_URL}"
+  echo "🎯 Target:   ${new_url}"
+  echo ""
+
+  local files
+  mapfile -t files < <(find_affected_files)
+
+  if [[ ${#files[@]} -eq 0 ]]; then
+    echo "✅ No files contain template references. Repository already initialized."
+    exit 0
+  fi
+
+  echo "${#files[@]} file(s) with template references:"
+  for file in "${files[@]}"; do
+    echo "  📄 ${file#./}"
+  done
+  echo ""
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "⚠️  Dry-run mode — no files modified."
+    exit 0
+  fi
+
+  local count=0
+  for file in "${files[@]}"; do
+    sed -i "s|${TEMPLATE_SLUG}|${new_slug}|g" "$file"
+    echo "  ✅ Updated: ${file#./}"
+    count=$((count + 1))
+  done
+
+  echo ""
+  echo "✅ Done — updated ${count} file(s)."
+  echo "   ${TEMPLATE_URL}"
+  echo "   → ${new_url}"
+  echo ""
+  echo "💡 Next steps:"
+  echo "   1. Review changes:  git diff"
+  echo "   2. Commit:          git add -A && git commit -m 'chore: initialize from template'"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds two scripts that replace all hardcoded accelerator template references with the new repository's own URL. Run once after creating a new repo from the accelerator template.

## Changes

- `scripts/init-from-template.mjs` — Node.js variant, invoked via `npm run init`
- `scripts/init-from-template.sh` — bash variant
- `package.json` — adds `init` script alias

## Usage

```bash
npm run init
npm run init -- --dry-run
bash scripts/init-from-template.sh --dry-run
```