### PR TITLE
fix(branding): complete APEX rebrand — hero, PlatformOps cleanup

### DIFF
--- a/.github/agents/e2e-orchestrator.agent.md
+++ b/.github/agents/e2e-orchestrator.agent.md
@@ -47,7 +47,7 @@ tools:
 <!-- Recommended reasoning_effort: high -->
 
 Autonomous orchestrator for the RALPH-style E2E workflow evaluation loop.
-Runs all 7 PlatformOps steps without human gates, validates every artifact,
+Runs all 7 APEX steps without human gates, validates every artifact,
 and produces a scored benchmark report with lessons learned.
 
 ## Batch Execution (Multi-Run Mode)

--- a/.github/skills/azure-diagnostics/references/infraops-remediation-playbooks.md
+++ b/.github/skills/azure-diagnostics/references/infraops-remediation-playbooks.md
@@ -45,7 +45,7 @@ Structure the diagnostic report as:
 ## Diagnostic Report: {resource-name}
 
 **Assessment Date**: {date}
-**Assessed By**: PlatformOps Diagnose Agent
+**Assessed By**: APEX Diagnose Agent
 **Overall Health**: 🟢 Healthy | 🟡 Degraded | 🔴 Unhealthy
 
 ### Findings Summary

--- a/.github/skills/azure-validate/SKILL.digest.md
+++ b/.github/skills/azure-validate/SKILL.digest.md
@@ -28,7 +28,7 @@ Compact reference for agent startup. Read full `SKILL.md` for details.
 
 > _See SKILL.md for full content._
 
-## PlatformOps-Specific References
+## APEX-Specific References
 
 - [InfraOps Preflight Validation](references/infraops-preflight.md) — CLI auth checks, known issues, governance-to-code mapping, stop rules
   > If any validation failed, fix the issues and re-run azure-validate before proceeding.

--- a/.github/skills/azure-validate/SKILL.md
+++ b/.github/skills/azure-validate/SKILL.md
@@ -64,7 +64,7 @@ metadata:
 >
 > After ALL validations pass, you **MUST** invoke **azure-deploy** to execute the deployment. Do NOT attempt to run `azd up`, `azd deploy`, or any deployment commands directly. Let azure-deploy handle execution.
 
-## PlatformOps-Specific References
+## APEX-Specific References
 
 - [InfraOps Preflight Validation](references/infraops-preflight.md) — CLI auth checks, known issues, governance-to-code mapping, stop rules
   > If any validation failed, fix the issues and re-run azure-validate before proceeding.

--- a/.github/skills/azure-validate/SKILL.minimal.md
+++ b/.github/skills/azure-validate/SKILL.minimal.md
@@ -9,7 +9,7 @@
 
 **Steps**:
 
-**PlatformOps-Specific References**:
+**APEX-Specific References**:
 
 **Reference Index**:
 Load these on demand — do NOT read all at once:

--- a/assets/readme-workflow.excalidraw
+++ b/assets/readme-workflow.excalidraw
@@ -75,12 +75,12 @@
       "strokeStyle": "solid",
       "roughness": 0,
       "opacity": 100,
-      "text": "Agentic PlatformOps Workflow",
+      "text": "APEX Workflow",
       "fontSize": 28,
       "fontFamily": 5,
       "textAlign": "center",
       "verticalAlign": "top",
-      "originalText": "Agentic PlatformOps Workflow",
+      "originalText": "APEX Workflow",
       "lineHeight": 1.25
     },
     {

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -194,7 +194,7 @@ state integrity, and timing performance. Composite score 0–100 with letter gra
 
 ### E2E Orchestrator
 
-Orchestration agent that drives the Ralph Loop. Executes all PlatformOps steps without human
+Orchestration agent that drives the Ralph Loop. Executes all APEX steps without human
 gates, with pre-validation, self-correction, challenger reviews, and benchmark collection.
 Supports both Bicep and Terraform IaC tracks. Invoked via prompt files, not direct @mention.
 
@@ -344,7 +344,7 @@ JSON-RPC, a lightweight RPC protocol encoded in JSON.
 ### Ralph Loop
 
 An autonomous, self-correcting E2E evaluation workflow based on the
-[RALPH pattern](https://ghuntley.com/ralph/). Runs all PlatformOps pipeline steps without
+[RALPH pattern](https://ghuntley.com/ralph/). Runs all APEX pipeline steps without
 human gates, with built-in self-correction, challenger reviews, and benchmark scoring.
 Supports both Bicep and Terraform IaC tracks.
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,11 +1,11 @@
 # E2E Testing with Ralph Loop
 
-End-to-end testing for the PlatformOps pipeline using the autonomous
+End-to-end testing for the APEX pipeline using the autonomous
 [RALPH Loop](https://ghuntley.com/ralph/) pattern.
 
 ## What Is Ralph Loop?
 
-Ralph Loop is a self-correcting E2E evaluation workflow that runs all PlatformOps
+Ralph Loop is a self-correcting E2E evaluation workflow that runs all APEX
 pipeline steps **without human gates**. It validates the entire agent pipeline
 autonomously — from requirements through deployment to documentation — with
 built-in self-correction, challenger reviews, and benchmark scoring.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,10 @@
 ![Version](https://img.shields.io/badge/version-0.10.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-Transform Azure project requirements into deploy-ready IaC code (Bicep or Terraform)
-using coordinated AI agents and reusable skills, aligned with the Azure Well-Architected
-Framework and Azure Verified Modules.
+Transform Azure platform engineering for IT Pros. Powered by GitHub Copilot
+and specialized AI agents, APEX converts requirements into architecture diagrams,
+governance-aligned designs, and deploy-ready Bicep or Terraform templates —
+with built-in pricing, compliance, and automation.
 
 **Who is this for?** DevOps engineers, platform engineers, and IT Pros who want to
 accelerate Azure platform engineering with AI-assisted workflows.

--- a/site/src/content/docs/guides/e2e-testing.md
+++ b/site/src/content/docs/guides/e2e-testing.md
@@ -3,12 +3,12 @@ title: "E2E Testing with Ralph Loop"
 description: "End-to-end testing with the Ralph Loop pattern"
 ---
 
-End-to-end testing for the PlatformOps pipeline using the autonomous
+End-to-end testing for the APEX pipeline using the autonomous
 [RALPH Loop](https://ghuntley.com/ralph/) pattern.
 
 ## What Is Ralph Loop?
 
-Ralph Loop is a self-correcting E2E evaluation workflow that runs all PlatformOps
+Ralph Loop is a self-correcting E2E evaluation workflow that runs all APEX
 pipeline steps **without human gates**. It validates the entire agent pipeline
 autonomously — from requirements through deployment to documentation — with
 built-in self-correction, challenger reviews, and benchmark scoring.

--- a/site/src/content/docs/guides/prompt-guide/index.mdx
+++ b/site/src/content/docs/guides/prompt-guide/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Prompt Guide"
-description: "Guide to effective prompting with PlatformOps agents"
+description: "Guide to effective prompting with APEX agents"
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -9,15 +9,15 @@ import AgentChat from "../../components/AgentChat.astro";
 
 <section class="landing-hero not-content">
   <div class="landing-hero__copy">
-    <p class="landing-eyebrow">Multi-Agent Azure IaC</p>
+    <p class="landing-eyebrow">Agentic Platform Engineering eXperience for Azure</p>
     <h1>
-      <span>Agentic</span>
-      <span>PlatformOps</span>
+      <span>APEX</span>
     </h1>
     <p class="landing-hero__tagline">
-      Transform Azure project requirements into deploy-ready IaC code
-      using coordinated AI agents, aligned with the Azure Well-Architected
-      Framework — Bicep or Terraform.
+      Transform Azure platform engineering for IT Pros. Powered by GitHub Copilot
+      and specialized AI agents, APEX converts requirements into architecture diagrams,
+      governance-aligned designs, and deploy-ready Bicep or Terraform templates —
+      with built-in pricing, compliance, and automation.
     </p>
 
     <div class="landing-hero__actions">

--- a/site/src/content/docs/reference/glossary.md
+++ b/site/src/content/docs/reference/glossary.md
@@ -195,7 +195,7 @@ state integrity, and timing performance. Composite score 0–100 with letter gra
 
 ### E2E Orchestrator
 
-Orchestration agent that drives the Ralph Loop. Executes all PlatformOps steps without human
+Orchestration agent that drives the Ralph Loop. Executes all APEX steps without human
 gates, with pre-validation, self-correction, challenger reviews, and benchmark collection.
 Supports both Bicep and Terraform IaC tracks. Invoked via prompt files, not direct @mention.
 
@@ -345,7 +345,7 @@ JSON-RPC, a lightweight RPC protocol encoded in JSON.
 ### Ralph Loop
 
 An autonomous, self-correcting E2E evaluation workflow based on the
-[RALPH pattern](https://ghuntley.com/ralph/). Runs all PlatformOps pipeline steps without
+[RALPH pattern](https://ghuntley.com/ralph/). Runs all APEX pipeline steps without
 human gates, with built-in self-correction, challenger reviews, and benchmark scoring.
 Supports both Bicep and Terraform IaC tracks.
 


### PR DESCRIPTION
## Summary\n\nFollows up on PR #286 — the squash merge didn't include the hero/PlatformOps cleanup commit. This PR applies those changes directly to `main`.\n\n### Changes\n\n**Astro site hero** (`site/src/content/docs/index.mdx`):\n- Heading: `Agentic PlatformOps` → **APEX**\n- Eyebrow: `Multi-Agent Azure IaC` → `Agentic Platform Engineering eXperience for Azure`\n- Tagline: rewritten with full value proposition\n\n**Landing page** (`docs/index.md`): matching copy update\n\n**13 files — standalone PlatformOps → APEX**:\n- `docs/GLOSSARY.md`, `docs/e2e-testing.md`\n- `site/` glossary, e2e-testing, prompt-guide frontmatter\n- `.github/agents/e2e-orchestrator.agent.md`\n- `.github/skills/azure-validate/` (SKILL.md, digest, minimal)\n- `.github/skills/azure-diagnostics/references/infraops-remediation-playbooks.md`\n- `assets/readme-workflow.excalidraw`\n\n**Preserved** (historical/enforcement): changelog entries, terminology blocklist, Vale vocab\n\n### Validation\n\n- Terminology: 0 errors (1112 files)\n- All pre-commit/pre-push hooks passed"