### PR TITLE
feat(agents): update model assignments and docs guidance

### DIFF
--- a/.github/agent-registry.json
+++ b/.github/agent-registry.json
@@ -52,7 +52,7 @@
     },
     "design": {
       "agent": ".github/agents/04-design.agent.md",
-      "model": "GPT-5.4",
+      "model": "Claude Sonnet 4.6",
       "skills": [
         "drawio",
         "python-diagrams",
@@ -95,7 +95,7 @@
     "iac-code": {
       "bicep": {
         "agent": ".github/agents/06b-bicep-codegen.agent.md",
-        "model": "Claude Sonnet 4.6",
+        "model": "GPT-5.4",
         "skills": [
           "azure-defaults",
           "azure-artifacts",
@@ -108,7 +108,7 @@
       },
       "terraform": {
         "agent": ".github/agents/06t-terraform-codegen.agent.md",
-        "model": "Claude Sonnet 4.6",
+        "model": "GPT-5.4",
         "skills": [
           "azure-defaults",
           "azure-artifacts",
@@ -127,7 +127,7 @@
     "deploy": {
       "bicep": {
         "agent": ".github/agents/07b-bicep-deploy.agent.md",
-        "model": "Claude Sonnet 4.6",
+        "model": "GPT-5.4",
         "skills": [
           "azure-defaults",
           "azure-artifacts",
@@ -140,7 +140,7 @@
       },
       "terraform": {
         "agent": ".github/agents/07t-terraform-deploy.agent.md",
-        "model": "Claude Sonnet 4.6",
+        "model": "GPT-5.4",
         "skills": [
           "azure-defaults",
           "azure-artifacts",
@@ -231,25 +231,25 @@
     },
     "bicep-validate-subagent": {
       "agent": ".github/agents/_subagents/bicep-validate-subagent.agent.md",
-      "model": "GPT-5.4",
+      "model": "Claude Sonnet 4.6",
       "skills": ["azure-bicep-patterns"],
       "invokable": false
     },
     "bicep-whatif-subagent": {
       "agent": ".github/agents/_subagents/bicep-whatif-subagent.agent.md",
-      "model": "GPT-5.4",
+      "model": "Claude Sonnet 4.6",
       "skills": [],
       "invokable": false
     },
     "terraform-validate-subagent": {
       "agent": ".github/agents/_subagents/terraform-validate-subagent.agent.md",
-      "model": "GPT-5.4",
+      "model": "Claude Sonnet 4.6",
       "skills": ["terraform-patterns", "terraform-test"],
       "invokable": false
     },
     "terraform-plan-subagent": {
       "agent": ".github/agents/_subagents/terraform-plan-subagent.agent.md",
-      "model": "GPT-5.4",
+      "model": "Claude Sonnet 4.6",
       "skills": [],
       "invokable": false
     }

--- a/.github/agents/03-architect.agent.md
+++ b/.github/agents/03-architect.agent.md
@@ -311,14 +311,14 @@ Check `00-session-state.json` `decisions.complexity` to determine pass count per
 > skip pass 2 if pass 1 has 0 `must_fix` and <2 `should_fix`; skip pass 3 if pass 2 has 0 `must_fix`.
 
 > **Model routing**: For pass 1 (security-governance) or comprehensive reviews:
-> invoke `challenger-review-subagent` (GPT-5.4).
+> invoke `challenger-review-subagent`.
 > For pass 2 (architecture-reliability) and pass 3 (cost-feasibility):
 > invoke `challenger-review-subagent` with the appropriate `review_focus`
 > (model routing is handled internally by the subagent).
 
 ### Cost Estimate Review (1 pass)
 
-Invoke `challenger-review-subagent` (GPT-5.4):
+Invoke `challenger-review-subagent`:
 
 - `artifact_path` = `agent-output/{project}/03-des-cost-estimate.md`
 - `project_name` = `{project}`

--- a/.github/agents/04-design.agent.md
+++ b/.github/agents/04-design.agent.md
@@ -1,6 +1,6 @@
 ---
 name: 04-Design
-model: ["GPT-5.4"]
+model: ["Claude Sonnet 4.6"]
 description: Step 3 - Design Artifacts. Generates architecture diagrams and Architecture Decision Records (ADRs) for Azure infrastructure. Uses drawio skill for visual documentation and azure-adr skill for formal decision records. Optional step - users can skip to Implementation Planning.
 user-invocable: true
 agents: []
@@ -55,6 +55,30 @@ handoffs:
 # Design Agent
 
 <!-- Recommended reasoning_effort: high -->
+
+<investigate_before_answering>
+Read `02-architecture-assessment.md` before generating any design artifact.
+Review the architecture decisions, WAF analysis, and resource list to ensure diagrams
+and ADRs accurately reflect the approved architecture.
+</investigate_before_answering>
+
+<context_awareness>
+This is a large agent definition (~435 lines). At >60% context, load SKILL.digest.md variants.
+At >80% context, switch to SKILL.minimal.md and do not re-read predecessor artifacts.
+</context_awareness>
+
+<scope_fencing>
+This agent generates design artifacts only: architecture diagrams, ADRs, and cost estimate handoffs.
+Do not generate IaC code, modify architecture assessments, or make infrastructure decisions without an ADR.
+</scope_fencing>
+
+<output_contract>
+Expected output in `agent-output/{project}/`:
+
+- `03-des-diagram.drawio` — Architecture diagram (Draw.io format)
+- `03-des-adr-NNNN-{title}.md` — Architecture Decision Records
+- `03-des-cost-estimate.md` — Cost estimate handoff (optional)
+</output_contract>
 
 ## Scope
 

--- a/.github/agents/06b-bicep-codegen.agent.md
+++ b/.github/agents/06b-bicep-codegen.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 06b-Bicep CodeGen
 description: Expert Azure Bicep Infrastructure as Code specialist that creates near-production-ready Bicep templates following best practices and Azure Verified Modules standards. Validates, tests, and ensures code quality.
-model: ["Claude Sonnet 4.6"]
+model: ["GPT-5.4"]
 user-invocable: true
 agents: ["bicep-validate-subagent", "challenger-review-subagent"]
 tools:
@@ -54,30 +54,28 @@ handoffs:
 
 # Bicep Code Agent
 
-<!-- Recommended reasoning_effort: high -->
+## Investigate Before Answering
 
-<investigate_before_answering>
 Read the implementation plan and governance constraints before generating any Bicep code.
 Verify AVM module availability and parameter schemas via preflight checks.
 Do not assume resource configurations — validate against actual Azure API schemas.
-</investigate_before_answering>
 
-<context_awareness>
+## Context Awareness
+
 This is a large agent definition (~590 lines). At >60% context, load SKILL.digest.md variants.
 At >80% context, switch to SKILL.minimal.md and do not re-read predecessor artifacts.
-</context_awareness>
 
-<scope_fencing>
+## Scope Fencing
+
 This agent generates Bicep templates and validation artifacts only.
 Do not deploy infrastructure — that is the Deploy agent's responsibility.
 Do not modify architecture decisions — hand back to the Planner if the plan needs changes.
-</scope_fencing>
 
-<subagent_budget>
+## Subagent Budget
+
 This agent orchestrates 2 subagents: bicep-validate-subagent (lint+review), challenger-review-subagent.
 Invoke bicep-validate-subagent for combined lint and code review.
 Use challenger-review-subagent only for adversarial review after validation passes.
-</subagent_budget>
 
 ## Read Skills First
 
@@ -90,27 +88,44 @@ Before doing any work, read these skills:
 5. Read `.github/instructions/iac-best-practices.instructions.md` — governance mandate, dynamic tag list
 6. Read `.github/skills/context-shredding/SKILL.digest.md` — runtime compression for large plan/governance artifacts
 
-## DO / DON'T
+## Do
 
-| DO                                                                                           | DON'T                                                                                    |
-| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Run preflight check BEFORE writing any Bicep (Phase 1)                                       | Start coding before preflight check                                                      |
-| Use `askQuestions` to present blockers from Phase 1 + 1.5                                    | Silently halt on blockers without telling the user why                                   |
-| Do not list blockers in chat text asking user to reply manually                              | List blockers in chat and wait for a reply (wastes a round-trip)                         |
-| Use AVM modules for EVERY resource that has one                                              | Write raw Bicep when AVM exists                                                          |
-| Generate `uniqueSuffix` ONCE in `main.bicep`, pass to ALL modules                            | Hardcode unique strings                                                                  |
-| Apply baseline tags + governance extras                                                      | Use hardcoded tag lists ignoring governance                                              |
-| Parse `04-governance-constraints.json` — map each Deny policy to Bicep                       | Skip governance compliance mapping (HARD GATE)                                           |
-| Apply security baseline (TLS 1.2, HTTPS, managed identity, no public)                        | Use `APPINSIGHTS_INSTRUMENTATIONKEY` (use CONNECTION_STRING)                             |
-| PostgreSQL: set `activeDirectoryAuth: Enabled`, `passwordAuth: Disabled`                     | Allow password-only auth on any database (security baseline)                             |
-| APIM: check SKU compatibility matrix before VNet config (common-patterns.md)                 | Use `virtualNetworkType` on Standard/Basic v2 (classic model only)                       |
-| Front Door: use separate `location` (global) and `resourceLocation` (region)                 | Share a single location param for both profile and Private Link                          |
-| Key Vault: set `networkAcls.bypass: 'AzureServices'` when enabledForDeployment is true       | Set `bypass: 'None'` when enabledForDeployment/DiskEncryption/TemplateDeployment is true |
-| Use `take()` for length-constrained resources (KV≤24, Storage≤24)                            | Put hyphens in Storage Account names                                                     |
-| Use `resourceId(subscription().subscriptionId, ...)` for cross-RG refs at subscription scope | Use bare `resourceId(rgName, type, name)` from subscription-scope modules                |
-| Generate `azure.yaml` + `deploy.ps1` + `.bicepparam` per environment                         | Deploy — that's the Deploy agent's job                                                   |
-| Run `bicep build` + `bicep lint` after generation                                            | Proceed without checking AVM parameter types (known issues exist)                        |
-| Save `05-implementation-reference.md` + update project README                                | Use phase parameter if plan specifies single deployment                                  |
+- Run preflight check BEFORE writing any Bicep (Phase 1)
+- Use `askQuestions` to present blockers from Phase 1 + 1.5
+- Use AVM modules for EVERY resource that has one
+- Generate `uniqueSuffix` ONCE in `main.bicep`, pass to ALL modules
+- Apply baseline tags + governance extras
+- Parse `04-governance-constraints.json` — map each Deny policy to Bicep
+- Apply security baseline (TLS 1.2, HTTPS, managed identity, no public)
+- PostgreSQL: set `activeDirectoryAuth: Enabled`, `passwordAuth: Disabled`
+- APIM: check SKU compatibility matrix before VNet config (common-patterns.md)
+- Front Door: use separate `location` (global) and `resourceLocation` (region)
+- Key Vault: set `networkAcls.bypass: 'AzureServices'` when enabledForDeployment is true
+- Use `take()` for length-constrained resources (KV≤24, Storage≤24)
+- Use `resourceId(subscription().subscriptionId, ...)` for cross-RG refs at subscription scope
+- Generate `azure.yaml` + `deploy.ps1` + `.bicepparam` per environment
+- Run `bicep build` + `bicep lint` after generation
+- Save `05-implementation-reference.md` + update project README
+
+## Don't
+
+- Start coding before preflight check
+- Silently halt on blockers without telling the user why
+- List blockers in chat and wait for a reply (wastes a round-trip)
+- Write raw Bicep when AVM exists
+- Hardcode unique strings
+- Use hardcoded tag lists ignoring governance
+- Skip governance compliance mapping (HARD GATE)
+- Use `APPINSIGHTS_INSTRUMENTATIONKEY` (use CONNECTION_STRING)
+- Allow password-only auth on any database (security baseline)
+- Use `virtualNetworkType` on Standard/Basic v2 (classic model only)
+- Share a single location param for both profile and Private Link
+- Set `bypass: 'None'` when enabledForDeployment/DiskEncryption/TemplateDeployment is true
+- Put hyphens in Storage Account names
+- Use bare `resourceId(rgName, type, name)` from subscription-scope modules
+- Deploy — that's the Deploy agent's job
+- Proceed without checking AVM parameter types (known issues exist)
+- Use phase parameter if plan specifies single deployment
 
 ## Prerequisites Check
 
@@ -281,7 +296,8 @@ infra/bicep/{project}/
     └── ...
 ```
 
-<output_contract>
+## Output Contract
+
 Expected output in `infra/bicep/{project}/`:
 
 - `main.bicep` — Entry point with uniqueSuffix, orchestrates modules
@@ -289,20 +305,23 @@ Expected output in `infra/bicep/{project}/`:
 - `azure.yaml` — azd project manifest
 - `deploy.ps1` — PowerShell deployment script (legacy fallback)
 - `modules/*.bicep` — Per-resource AVM module wrappers
-  In `agent-output/{project}/`:
+
+In `agent-output/{project}/`:
+
 - `04-preflight-check.md` — Preflight validation results
 - `05-implementation-reference.md` — Template structure and validation status
-  Validation: `bicep build main.bicep` + `bicep lint main.bicep` + `npm run lint:artifact-templates`.
-  </output_contract>
 
-<user_updates_spec>
+Validation: `bicep build main.bicep` + `bicep lint main.bicep` + `npm run lint:artifact-templates`.
+
+## User Updates
+
 After completing each major phase, provide a brief status update in chat:
 
 - What was just completed (phase name, key results)
 - What comes next (next phase name)
 - Any blockers or decisions needed
-  This keeps the user informed during multi-phase operations.
-  </user_updates_spec>
+
+This keeps the user informed during multi-phase operations.
 
 ## Boundaries
 

--- a/.github/agents/06t-terraform-codegen.agent.md
+++ b/.github/agents/06t-terraform-codegen.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 06t-Terraform CodeGen
 description: Expert Azure Terraform Infrastructure as Code specialist that creates near-production-ready Terraform configurations following best practices and Azure Verified Modules (AVM-TF) standards. Validates, tests, and ensures code quality.
-model: ["Claude Sonnet 4.6"]
+model: ["GPT-5.4"]
 user-invocable: true
 agents: ["terraform-validate-subagent", "challenger-review-subagent"]
 tools:
@@ -57,30 +57,28 @@ handoffs:
 
 # Terraform Code Agent
 
-<!-- Recommended reasoning_effort: high -->
+## Investigate Before Answering
 
-<investigate_before_answering>
 Read the implementation plan and governance constraints before generating any Terraform code.
 Verify AVM-TF module availability and variable schemas via preflight checks.
 Do not assume resource configurations — validate against actual Terraform Registry data.
-</investigate_before_answering>
 
-<context_awareness>
+## Context Awareness
+
 This is a large agent definition (~590 lines). At >60% context, load SKILL.digest.md variants.
 At >80% context, switch to SKILL.minimal.md and do not re-read predecessor artifacts.
-</context_awareness>
 
-<scope_fencing>
+## Scope Fencing
+
 This agent generates Terraform configurations and validation artifacts only.
 Do not deploy infrastructure — that is the Deploy agent's responsibility.
 Do not modify architecture decisions — hand back to the Planner if the plan needs changes.
-</scope_fencing>
 
-<subagent_budget>
+## Subagent Budget
+
 This agent orchestrates 2 subagents: terraform-validate-subagent (lint+review), challenger-review-subagent.
 Invoke terraform-validate-subagent for combined lint and code review.
 Use challenger-review-subagent only for adversarial review after validation passes.
-</subagent_budget>
 
 **HCP GUARDRAIL**: Never write `terraform { cloud { } }` blocks or reference `TFE_TOKEN`.
 Always generate Azure Storage Account backend. Never use `terraform -target` for phased
@@ -97,22 +95,34 @@ Before doing any work, read these skills:
 5. Read `.github/instructions/iac-best-practices.instructions.md` — governance mandate, translation table
 6. Read `.github/skills/context-shredding/SKILL.digest.md` — runtime compression for large plan/governance artifacts
 
-## DO / DON'T
+## Do
 
-| DO                                                                    | DON'T                                                               |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Run preflight check BEFORE writing any Terraform (Phase 1)            | Start coding before preflight check                                 |
-| Use `askQuestions` to present blockers from Phase 1 + 1.5             | Silently halt on blockers without telling the user why              |
-| Do not list blockers in chat text asking user to reply manually       | List blockers in chat and wait for a reply (wastes a round-trip)    |
-| Use AVM-TF modules for EVERY resource that has one                    | Write raw `azurerm` when AVM-TF exists                              |
-| Generate unique suffix ONCE in `locals.tf`, pass to ALL resources     | Hardcode unique strings                                             |
-| Apply baseline tags + governance extras via `local.tags`              | Use hardcoded tag maps ignoring governance                          |
-| Parse `04-governance-constraints.json` — map Deny policies to TF args | Skip governance compliance mapping (HARD GATE)                      |
-| Apply security baseline (TLS 1.2, HTTPS, managed identity, no public) | Use `APPINSIGHTS_INSTRUMENTATIONKEY` (use CONNECTION_STRING)        |
-| Use `var.deployment_phase` + `count` for phased deployment            | Use `terraform -target` or `terraform { cloud { } }` / `TFE_TOKEN`  |
-| Generate bootstrap + deploy scripts (bash + PS)                       | Put hyphens in Storage Account names                                |
-| Run `terraform validate` + `terraform fmt -check` after generation    | Deploy — that's the Deploy agent's job                              |
-| Save `05-implementation-reference.md` + update project README         | Proceed without checking AVM-TF variable types (known issues exist) |
+- Run preflight check BEFORE writing any Terraform (Phase 1)
+- Use `askQuestions` to present blockers from Phase 1 + 1.5
+- Use AVM-TF modules for EVERY resource that has one
+- Generate unique suffix ONCE in `locals.tf`, pass to ALL resources
+- Apply baseline tags + governance extras via `local.tags`
+- Parse `04-governance-constraints.json` — map Deny policies to TF args
+- Apply security baseline (TLS 1.2, HTTPS, managed identity, no public)
+- Use `var.deployment_phase` + `count` for phased deployment
+- Generate bootstrap + deploy scripts (bash + PS)
+- Run `terraform validate` + `terraform fmt -check` after generation
+- Save `05-implementation-reference.md` + update project README
+
+## Don't
+
+- Start coding before preflight check
+- Silently halt on blockers without telling the user why
+- List blockers in chat and wait for a reply (wastes a round-trip)
+- Write raw `azurerm` when AVM-TF exists
+- Hardcode unique strings
+- Use hardcoded tag maps ignoring governance
+- Skip governance compliance mapping (HARD GATE)
+- Use `APPINSIGHTS_INSTRUMENTATIONKEY` (use CONNECTION_STRING)
+- Use `terraform -target` or `terraform { cloud { } }` / `TFE_TOKEN`
+- Put hyphens in Storage Account names
+- Deploy — that's the Deploy agent's job
+- Proceed without checking AVM-TF variable types (known issues exist)
 
 ## Prerequisites Check
 
@@ -269,7 +279,8 @@ Save validation status in `05-implementation-reference.md`. Run `npm run lint:ar
 Read `terraform-patterns/references/project-scaffold.md` for the standard
 file structure, `locals.tf` pattern, and phased deployment pattern.
 
-<output_contract>
+## Output Contract
+
 Expected output in `infra/terraform/{project}/`:
 
 - `versions.tf`, `providers.tf`, `backend.tf` — Provider and backend config
@@ -278,20 +289,23 @@ Expected output in `infra/terraform/{project}/`:
 - `outputs.tf` — Deployment outputs
 - `bootstrap-backend.sh` + `bootstrap-backend.ps1` — State backend bootstrap
 - `deploy.sh` + `deploy.ps1` — Deployment scripts
-  In `agent-output/{project}/`:
+
+In `agent-output/{project}/`:
+
 - `04-preflight-check.md` — Preflight validation results
 - `05-implementation-reference.md` — Configuration structure and validation status
-  Validation: `terraform validate` + `terraform fmt -check` + `npm run lint:artifact-templates`.
-  </output_contract>
 
-<user_updates_spec>
+Validation: `terraform validate` + `terraform fmt -check` + `npm run lint:artifact-templates`.
+
+## User Updates
+
 After completing each major phase, provide a brief status update in chat:
 
 - What was just completed (phase name, key results)
 - What comes next (next phase name)
 - Any blockers or decisions needed
-  This keeps the user informed during multi-phase operations.
-  </user_updates_spec>
+
+This keeps the user informed during multi-phase operations.
 
 ## Boundaries
 

--- a/.github/agents/07b-bicep-deploy.agent.md
+++ b/.github/agents/07b-bicep-deploy.agent.md
@@ -1,6 +1,6 @@
 ---
 name: 07b-Bicep Deploy
-model: ["Claude Sonnet 4.6"]
+model: ["GPT-5.4"]
 description: Executes Azure deployments using generated Bicep templates. Uses azd provision (preferred when azure.yaml exists) or deploy.ps1 (legacy fallback), performs what-if analysis, and manages deployment lifecycle. Step 6 of the agentic workflow.
 argument-hint: Deploy the Bicep templates for a specific project
 user-invocable: true
@@ -71,12 +71,10 @@ handoffs:
 
 # Deploy Agent
 
-<!-- Recommended reasoning_effort: medium -->
+## Context Awareness
 
-<context_awareness>
 This is a large agent definition (~537 lines). At >60% context, load SKILL.digest.md variants.
 At >80% context, switch to SKILL.minimal.md and do not re-read predecessor artifacts.
-</context_awareness>
 
 ## Read Skills First
 
@@ -149,24 +147,34 @@ If running in a PR context (branch ≠ `main`), after deployment completes:
 3. If all gates pass and review approved, execute auto-merge
 4. See `.github/skills/github-operations/references/smart-pr-flow.md` for full protocol
 
-## DO / DON'T
+## Do
 
-| DO                                                                | DON'T                                                     |
-| ----------------------------------------------------------------- | --------------------------------------------------------- |
-| Run preflight validation BEFORE deployment                        | Deploy without running what-if first                      |
-| Scan param file for placeholders; use `askQuestions` tool         | Pass param files with literal `<replace-with-*>` strings  |
-| Do not list placeholders in chat asking user to reply manually    | List placeholders in chat text and wait for a reply       |
-| Check `04-implementation-plan.md` for deployment strategy         | Skip phase gates when plan specifies phased deployment    |
-| Deploy phases one at a time with approval gates                   | Use `--output yaml/json` for what-if (disables rendering) |
-| Use **default output** for what-if (no `--output` flag)           | Auto-approve production deployments                       |
-| Validate auth via `az account get-access-token` (not just `show`) | Proceed if what-if shows Delete ops without approval      |
-| Present what-if summary; wait for user approval                   | Proceed if `bicep build` fails                            |
-| Require explicit approval for Delete (`-`) operations             | Create/modify Bicep templates — hand back to Code agent   |
-| Generate `deploy.ps1` with `-SkipValidation` switch               | Re-run build+lint when Step 5 validation is current       |
-| Generate `06-deployment-summary.md` after deployment              |                                                           |
-| Verify resources via Azure Resource Graph post-deploy             |                                                           |
-| Scan what-if output for deprecation signals                       |                                                           |
-| Update `agent-output/{project}/README.md` — mark Step 6 complete  |                                                           |
+- Run preflight validation BEFORE deployment
+- Scan param file for placeholders; use `askQuestions` tool
+- Check `04-implementation-plan.md` for deployment strategy
+- Deploy phases one at a time with approval gates
+- Use **default output** for what-if (no `--output` flag)
+- Validate auth via `az account get-access-token` (not just `show`)
+- Present what-if summary; wait for user approval
+- Require explicit approval for Delete (`-`) operations
+- Generate `deploy.ps1` with `-SkipValidation` switch
+- Generate `06-deployment-summary.md` after deployment
+- Verify resources via Azure Resource Graph post-deploy
+- Scan what-if output for deprecation signals
+- Update `agent-output/{project}/README.md` — mark Step 6 complete
+
+## Don't
+
+- Deploy without running what-if first
+- Pass param files with literal `<replace-with-*>` strings
+- List placeholders in chat text and wait for a reply
+- Skip phase gates when plan specifies phased deployment
+- Use `--output yaml/json` for what-if (disables rendering)
+- Auto-approve production deployments
+- Proceed if what-if shows Delete ops without approval
+- Proceed if `bicep build` fails
+- Create/modify Bicep templates — hand back to Code agent
+- Re-run build+lint when Step 5 validation is current
 
 ## Prerequisites Check
 
@@ -399,24 +407,25 @@ Mark status as "Simulated".
 Follow the **Copy-Then-Fill Artifact Protocol** above — copy the template, fill placeholders, validate.
 Do NOT compose the artifact from memory. Do NOT skip the post-save lint check.
 
-<output_contract>
+## Output Contract
+
 Expected output in `agent-output/{project}/`:
 
 - `06-deployment-summary.md` — Deployment results (copy-then-fill from template)
-  Validation: `npm run lint:artifact-templates -- agent-output/{project}/06-deployment-summary.md`.
-  </output_contract>
 
-<empty_result_recovery>
+Validation: `npm run lint:artifact-templates -- agent-output/{project}/06-deployment-summary.md`.
+
+## Empty Result Recovery
+
 If what-if returns no changes (all resources `NoChange`), report the result and confirm with the user.
 If what-if fails due to missing resource group, create the RG first and retry once.
 If deployment returns 0 resources created, verify the template was not empty and report findings.
-</empty_result_recovery>
 
-<default_follow_through_policy>
+## Default Follow Through Policy
+
 When an approval gate is presented and the user approves, proceed immediately to the next phase.
 Do not re-confirm or ask additional questions after approval is given.
 If the user provides a custom response at an approval gate, interpret it as instructions and adapt.
-</default_follow_through_policy>
 
 ## Boundaries
 

--- a/.github/agents/07t-terraform-deploy.agent.md
+++ b/.github/agents/07t-terraform-deploy.agent.md
@@ -1,6 +1,6 @@
 ---
 name: 07t-Terraform Deploy
-model: ["Claude Sonnet 4.6"]
+model: ["GPT-5.4"]
 description: Executes Azure deployments using generated Terraform configurations. Runs bootstrap and deploy scripts, performs terraform plan preview, manages phase-aware deployment lifecycle. Step 6 of the agentic workflow.
 argument-hint: Deploy the Terraform configuration for a specific project
 user-invocable: true
@@ -70,12 +70,10 @@ handoffs:
 
 # Terraform Deploy Agent
 
-<!-- Recommended reasoning_effort: medium -->
+## Context Awareness
 
-<context_awareness>
 This is a large agent definition (~576 lines). At >60% context, load SKILL.digest.md variants.
 At >80% context, switch to SKILL.minimal.md and do not re-read predecessor artifacts.
-</context_awareness>
 
 ## Read Skills First
 
@@ -150,23 +148,33 @@ Run `npm run validate:iac-security-baseline` before terraform plan.
 If violations found → STOP, hand back to Code agent.
 Skip if `05-implementation-reference.md` confirms `security_validation_status: PASSED`.
 
-## DO / DON'T
+## Do
 
-| DO                                                                       | DON'T                                                                    |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| Validate Azure CLI token FIRST (`az account get-access-token`)           | Deploy without running `terraform plan` first                            |
-| Verify state backend storage account BEFORE `terraform init`             | Skip phase gates when plan specifies phased deployment                   |
-| Offer `bootstrap-backend.sh/.ps1` if backend missing                     | Use `terraform -target` — code is phase-gated via `var.deployment_phase` |
-| Scan tfvars for placeholders; use `askQuestions` tool                    | Pass tfvars with literal `<replace-with-*>` strings to plan/apply        |
-| Do not list placeholders in chat asking user to reply manually           | List placeholders in chat text and wait for a reply                      |
-| Run `terraform validate` and `terraform fmt -check` before planning      | Auto-approve production deployments                                      |
-| Check `04-implementation-plan.md` for deployment strategy                | Proceed if plan shows resource destruction without approval              |
-| Deploy phases one at a time with `var.deployment_phase` + approval gates | Proceed if `terraform validate` fails                                    |
-| Present plan summary; wait for user approval before applying             | Create/modify Terraform configs — hand back to Code agent                |
-| Require explicit approval for destruction (`- destroy`) operations       | Run `terraform init` without verifying backend exists                    |
-| Generate `06-deployment-summary.md` after deployment                     |                                                                          |
-| Run `terraform output` + Azure Resource Graph post-deployment            |                                                                          |
-| Update `agent-output/{project}/README.md` — mark Step 6 complete         |                                                                          |
+- Validate Azure CLI token FIRST (`az account get-access-token`)
+- Verify state backend storage account BEFORE `terraform init`
+- Offer `bootstrap-backend.sh/.ps1` if backend missing
+- Scan tfvars for placeholders; use `askQuestions` tool
+- Run `terraform validate` and `terraform fmt -check` before planning
+- Check `04-implementation-plan.md` for deployment strategy
+- Deploy phases one at a time with `var.deployment_phase` + approval gates
+- Present plan summary; wait for user approval before applying
+- Require explicit approval for destruction (`- destroy`) operations
+- Generate `06-deployment-summary.md` after deployment
+- Run `terraform output` + Azure Resource Graph post-deployment
+- Update `agent-output/{project}/README.md` — mark Step 6 complete
+
+## Don't
+
+- Deploy without running `terraform plan` first
+- Skip phase gates when plan specifies phased deployment
+- Use `terraform -target` — code is phase-gated via `var.deployment_phase`
+- Pass tfvars with literal `<replace-with-*>` strings to plan/apply
+- List placeholders in chat text and wait for a reply
+- Auto-approve production deployments
+- Proceed if plan shows resource destruction without approval
+- Proceed if `terraform validate` fails
+- Create/modify Terraform configs — hand back to Code agent
+- Run `terraform init` without verifying backend exists
 
 ## Prerequisites Check
 
@@ -379,24 +387,25 @@ with plan results, mark status as "Plan Only — Not Applied".
 Follow the **Copy-Then-Fill Artifact Protocol** above — copy the template, fill placeholders, validate.
 Do NOT compose the artifact from memory. Do NOT skip the post-save lint check.
 
-<output_contract>
+## Output Contract
+
 Expected output in `agent-output/{project}/`:
 
 - `06-deployment-summary.md` — Deployment results (copy-then-fill from template)
-  Validation: `npm run lint:artifact-templates -- agent-output/{project}/06-deployment-summary.md`.
-  </output_contract>
 
-<empty_result_recovery>
+Validation: `npm run lint:artifact-templates -- agent-output/{project}/06-deployment-summary.md`.
+
+## Empty Result Recovery
+
 If terraform plan shows no changes, report the result and confirm with the user before proceeding.
 If plan fails due to missing backend, offer to run bootstrap scripts and retry once.
 If apply completes with 0 resources, verify the configuration and deployment_phase variable.
-</empty_result_recovery>
 
-<default_follow_through_policy>
+## Default Follow Through Policy
+
 When an approval gate is presented and the user approves, proceed immediately to the next phase.
 Do not re-confirm or ask additional questions after approval is given.
 If the user provides a custom response at an approval gate, interpret it as instructions and adapt.
-</default_follow_through_policy>
 
 ## Boundaries
 

--- a/.github/agents/_subagents/bicep-validate-subagent.agent.md
+++ b/.github/agents/_subagents/bicep-validate-subagent.agent.md
@@ -1,7 +1,7 @@
 ---
 name: bicep-validate-subagent
 description: "Bicep validation subagent. Runs lint (bicep lint + build) first, then code review (AVM standards, naming, security baseline, governance compliance). Returns structured PASS/FAIL with diagnostics and APPROVED/NEEDS_REVISION/FAILED verdict."
-model: ["GPT-5.4"]
+model: ["Claude Sonnet 4.6"]
 user-invocable: false
 disable-model-invocation: false
 agents: []

--- a/.github/agents/_subagents/bicep-whatif-subagent.agent.md
+++ b/.github/agents/_subagents/bicep-whatif-subagent.agent.md
@@ -1,7 +1,7 @@
 ---
 name: bicep-whatif-subagent
 description: Bicep deployment preview subagent. Runs az deployment group what-if to preview changes before deployment. Analyzes policy violations, resource changes, and cost impact. Returns structured summary for parent agent review.
-model: ["GPT-5.4"]
+model: ["Claude Sonnet 4.6"]
 user-invocable: false
 disable-model-invocation: false
 agents: []

--- a/.github/agents/_subagents/terraform-plan-subagent.agent.md
+++ b/.github/agents/_subagents/terraform-plan-subagent.agent.md
@@ -1,7 +1,7 @@
 ---
 name: terraform-plan-subagent
 description: Terraform deployment preview subagent. Runs terraform plan to preview infrastructure changes before deployment. Classifies resources into create/update/destroy/replace, highlights destructive operations requiring explicit approval, and returns a structured change summary.
-model: ["GPT-5.4"]
+model: ["Claude Sonnet 4.6"]
 user-invocable: false
 disable-model-invocation: false
 agents: []

--- a/.github/agents/_subagents/terraform-validate-subagent.agent.md
+++ b/.github/agents/_subagents/terraform-validate-subagent.agent.md
@@ -1,7 +1,7 @@
 ---
 name: terraform-validate-subagent
 description: "Terraform validation subagent. Runs lint (fmt -check, validate, tfsec) first, then code review (AVM-TF standards, naming, security baseline, RBAC, governance compliance). Returns structured PASS/FAIL with diagnostics and APPROVED/NEEDS_REVISION/FAILED verdict."
-model: ["GPT-5.4"]
+model: ["Claude Sonnet 4.6"]
 user-invocable: false
 disable-model-invocation: false
 agents: []

--- a/.github/instructions/agent-authoring.instructions.md
+++ b/.github/instructions/agent-authoring.instructions.md
@@ -106,11 +106,11 @@ Agents that specify `Claude Opus 4.6` as priority model do so deliberately:
 - **Opus-first agents** (requirements, architect, iac-plan, diagnose,
   context-optimizer) require deeper reasoning for architecture decisions,
   WAF assessments, planning accuracy, and complex analysis
-- **GPT-5.4 agents** (orchestrator, design, governance, as-built, challenger wrapper,
-  e2e-orchestrator, and selected subagents) prioritize
+- **GPT-5.4 agents** (orchestrator, governance, as-built, challenger wrapper,
+  e2e-orchestrator, codegen, deploy) prioritize
   strong general reasoning for orchestration, diagrams, governance synthesis,
-  documentation generation, and structured reviews
-- **Claude Sonnet 4.6 agents** (orchestrator fast path, codegen, deploy) balance
+  documentation generation, code generation, deployment execution, and structured reviews
+- **Claude Sonnet 4.6 agents** (orchestrator fast path, design, and validation/preview subagents) balance
   speed with strong execution quality for implementation
 - **GPT-5.3-Codex subagents** handle narrow, high-throughput validation or preview tasks
 
@@ -122,16 +122,16 @@ Current model assignments:
 | Orchestrator (Fast Path)  | Claude Sonnet 4.6       | Streamlined orchestration|
 | Requirements           | Claude Opus 4.6         | Deep understanding       |
 | Architect              | Claude Opus 4.6         | WAF analysis + cost      |
-| Design                 | GPT-5.4                 | Diagram generation       |
+| Design                 | Claude Sonnet 4.6       | Diagram generation       |
 | Governance             | GPT-5.4                 | Governance discovery     |
 | IaC Planner (unified)  | Claude Opus 4.6         | Planning accuracy        |
-| Bicep / Terraform Code | Claude Sonnet 4.6       | Code generation          |
-| Deploy                 | Claude Sonnet 4.6       | Deployment execution     |
+| Bicep / Terraform Code | GPT-5.4                 | Code generation          |
+| Deploy                 | GPT-5.4                 | Deployment execution     |
 | As-Built               | GPT-5.4                 | Documentation generation |
 | Diagnose               | Claude Opus 4.6         | Complex troubleshooting  |
 | Context Optimizer      | Claude Opus 4.6         | Deep analysis            |
 | Challenger wrapper     | GPT-5.4                 | Review orchestration     |
-| Subagents              | GPT-5.4 / GPT-5.3-Codex | Fast isolated validation |
+| Subagents              | Claude Sonnet 4.6 / GPT-5.3-Codex | Isolated validation |
 
 **Rules:**
 

--- a/.github/instructions/agent-definitions.instructions.md
+++ b/.github/instructions/agent-definitions.instructions.md
@@ -102,30 +102,32 @@ Agents that specify `Claude Opus 4.6` as priority model do so deliberately:
 - **Opus-first agents** (requirements, architect, iac-plan, diagnose,
   context-optimizer) require deeper reasoning for architecture decisions,
   WAF assessments, planning accuracy, and complex analysis
-- **GPT-5.4 agents** (design, governance, as-built, and selected subagents) prioritize
-  strong general reasoning for diagrams, governance synthesis, documentation generation,
-  and structured reviews
-- **Claude Sonnet 4.6 agents** (orchestrator fast path, codegen, deploy, challenger wrapper)
-  balance speed with strong execution quality for implementation and orchestration
+- **GPT-5.4 agents** (orchestrator, governance, as-built, challenger wrapper,
+  e2e-orchestrator, codegen, deploy) prioritize
+  strong general reasoning for orchestration, code generation, deployment execution,
+  governance synthesis, documentation generation, and structured reviews
+- **Claude Sonnet 4.6 agents** (orchestrator fast path, design, and validation/preview subagents)
+  balance speed with strong execution quality for implementation
 - **GPT-5.3-Codex subagents** handle narrow, high-throughput validation or preview tasks
 
 Current model assignments:
 
-| Agent / Group            | Model                   | Rationale                 |
-| ------------------------ | ----------------------- | ------------------------- |
-| Orchestrator             | GPT-5.4                 | Multi-step coordination   |
-| Orchestrator (Fast Path) | Claude Sonnet 4.6       | Streamlined orchestration |
-| Requirements             | Claude Opus 4.6         | Deep understanding        |
-| Architect                | Claude Opus 4.6         | WAF analysis + cost       |
-| Design                   | GPT-5.4                 | Diagram generation        |
-| Governance               | GPT-5.4                 | Governance discovery      |
-| Bicep / Terraform Plan   | Claude Opus 4.6         | Planning accuracy         |
-| Bicep / Terraform Code   | Claude Sonnet 4.6       | Code generation           |
-| Deploy                   | Claude Sonnet 4.6       | Deployment execution      |
-| As-Built                 | GPT-5.4                 | Documentation generation  |
-| Diagnose                 | Claude Opus 4.6         | Complex troubleshooting   |
-| Challenger wrapper       | Claude Sonnet 4.6       | Review orchestration      |
-| Subagents                | GPT-5.4 / GPT-5.3-Codex | Fast isolated validation  |
+| Agent / Group            | Model                             | Rationale                 |
+| ------------------------ | --------------------------------- | ------------------------- |
+| Orchestrator             | GPT-5.4                           | Multi-step coordination   |
+| Orchestrator (Fast Path) | Claude Sonnet 4.6                 | Streamlined orchestration |
+| Requirements             | Claude Opus 4.6                   | Deep understanding        |
+| Architect                | Claude Opus 4.6                   | WAF analysis + cost       |
+| Design                   | Claude Sonnet 4.6                 | Diagram generation        |
+| Governance               | GPT-5.4                           | Governance discovery      |
+| Bicep / Terraform Plan   | Claude Opus 4.6                   | Planning accuracy         |
+| Bicep / Terraform Code   | GPT-5.4                           | Code generation           |
+| Deploy                   | GPT-5.4                           | Deployment execution      |
+| As-Built                 | GPT-5.4                           | Documentation generation  |
+| Diagnose                 | Claude Opus 4.6                   | Complex troubleshooting   |
+| Context Optimizer        | Claude Opus 4.6                   | Deep analysis             |
+| Challenger wrapper       | GPT-5.4                           | Review orchestration      |
+| Subagents                | Claude Sonnet 4.6 / GPT-5.3-Codex | Isolated validation       |
 
 **Rules:**
 

--- a/.github/prompts/01-orchestrator.prompt.md
+++ b/.github/prompts/01-orchestrator.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: "Kick off a new Azure platform engineering project through the full multi-step workflow with the Orchestrator agent."
 agent: "01-Orchestrator"
-model: "Claude Opus 4.6"
+model: "GPT-5.4"
 argument-hint: "Describe the Azure platform engineering project you want to build end-to-end"
 ---
 

--- a/.github/prompts/04-design.prompt.md
+++ b/.github/prompts/04-design.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: "Generate architecture diagrams and Architecture Decision Records (ADRs). Optional step — can be skipped."
 agent: "04-Design"
-model: "GPT-5.4"
+model: "Claude Sonnet 4.6"
 ---
 
 # Step 3 — Design Artifacts (Optional)

--- a/.github/prompts/resume-workflow.prompt.md
+++ b/.github/prompts/resume-workflow.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: "Resume the multi-step workflow from where it left off by reading session state and routing to the correct agent."
 agent: "01-Orchestrator"
-model: "Claude Opus 4.6"
+model: "GPT-5.4"
 ---
 
 # Resume Workflow

--- a/.github/skills/azure-defaults/references/adversarial-review-protocol.md
+++ b/.github/skills/azure-defaults/references/adversarial-review-protocol.md
@@ -120,13 +120,13 @@ Write each result to
 
 ## Model Routing
 
-Use the right model for each review lens:
+The model used for each review lens is determined by the `challenger-review-subagent` frontmatter (source of truth):
 
-| Pass                   | Lens                                | Subagent                     | Model   | Rationale                                                                  |
-| ---------------------- | ----------------------------------- | ---------------------------- | ------- | -------------------------------------------------------------------------- |
-| Pass 1 / Comprehensive | security-governance / comprehensive | `challenger-review-subagent` | GPT-5.4 | Deep logical reasoning for policy cross-reference, finding inconsistencies |
-| Pass 2                 | architecture-reliability            | `challenger-review-subagent` | GPT-5.4 | WAF/failure mode analysis. Structured checklist-driven.                    |
-| Pass 3                 | cost-feasibility                    | `challenger-review-subagent` | GPT-5.4 | Quantitative SKU analysis. Matches cost-estimate-subagent model.           |
+| Pass                   | Lens                                | Subagent                     | Rationale                                                                  |
+| ---------------------- | ----------------------------------- | ---------------------------- | -------------------------------------------------------------------------- |
+| Pass 1 / Comprehensive | security-governance / comprehensive | `challenger-review-subagent` | Deep logical reasoning for policy cross-reference, finding inconsistencies |
+| Pass 2                 | architecture-reliability            | `challenger-review-subagent` | WAF/failure mode analysis. Structured checklist-driven.                    |
+| Pass 3                 | cost-feasibility                    | `challenger-review-subagent` | Quantitative SKU analysis. Matches cost-estimate-subagent model.           |
 
 ## Parallel Invocation (Cross-Artifact Reviews)
 

--- a/.github/skills/azure-defaults/references/challenger-selection-rules.md
+++ b/.github/skills/azure-defaults/references/challenger-selection-rules.md
@@ -10,12 +10,14 @@ Selection rules for adversarial review passes in CodeGen agents (06b/06t).
 
 ## Pass Routing Table
 
-| Pass                 | Subagent                     | Model   | Lens                     | Condition                                                             |
-| -------------------- | ---------------------------- | ------- | ------------------------ | --------------------------------------------------------------------- |
-| 1                    | `challenger-review-subagent` | GPT-5.4 | security-governance      | Always required for all complexities                                  |
-| 2                    | `challenger-review-subagent` | GPT-5.4 | architecture-reliability | Skip if pass 1 has 0 must_fix AND <2 should_fix                       |
-| 3                    | `challenger-review-subagent` | GPT-5.4 | cost-feasibility         | Skip if pass 2 has 0 must_fix                                         |
-| Batch (complex only) | `challenger-review-subagent` | GPT-5.4 | passes 2+3 combined      | Use instead of separate pass 2+3 for complex projects to save context |
+Model is determined by the `challenger-review-subagent` frontmatter (source of truth).
+
+| Pass                 | Subagent                     | Lens                     | Condition                                                             |
+| -------------------- | ---------------------------- | ------------------------ | --------------------------------------------------------------------- |
+| 1                    | `challenger-review-subagent` | security-governance      | Always required for all complexities                                  |
+| 2                    | `challenger-review-subagent` | architecture-reliability | Skip if pass 1 has 0 must_fix AND <2 should_fix                       |
+| 3                    | `challenger-review-subagent` | cost-feasibility         | Skip if pass 2 has 0 must_fix                                         |
+| Batch (complex only) | `challenger-review-subagent` | passes 2+3 combined      | Use instead of separate pass 2+3 for complex projects to save context |
 
 ## Conditional Skip Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] — Unreleased
 
+### Changed
+
+- feat(agents): update model assignments for 9 agents/subagents.
+  Codegen agents (06b-Bicep CodeGen, 06t-Terraform CodeGen) and deploy agents
+  (07b-Bicep Deploy, 07t-Terraform Deploy) move from Claude Sonnet 4.6 → GPT-5.4.
+  Design agent (04-Design) moves from GPT-5.4 → Claude Sonnet 4.6.
+  Validation subagents (bicep-validate, bicep-whatif, terraform-validate, terraform-plan)
+  move from GPT-5.4 → Claude Sonnet 4.6.
+  Body content rewritten per model conventions: XML semantic blocks converted to markdown
+  headings for GPT-5.4 agents; Claude XML blocks added to 04-Design.
+  DO/DON'T tables converted to heading+list format for GPT-5.4 agents.
+- fix(agents): resolve Debt #18 — fix 2 orchestrator prompt model mismatches
+  (`01-orchestrator.prompt.md` and `resume-workflow.prompt.md` now match agent frontmatter).
+- refactor(docs): remove hardcoded model names from challenger-review-subagent references
+  in 03-architect body, docs, and skill reference files. Model is now sourced from
+  subagent frontmatter only.
+- chore(scripts): raise MAX_BODY_LINES from 400 → 500 in `scripts/_lib/paths.mjs`.
+
 ### Added
 
 - feat(drawio): replace jgraph `@drawio/mcp@1.1.1` with simonkurtz-MSFT `drawio-mcp-server` v3.0.1

--- a/QUALITY_SCORE.md
+++ b/QUALITY_SCORE.md
@@ -3,16 +3,16 @@
 > Project health at a glance. Updated by the doc-gardening workflow and manual review.
 > Exact entity counts are computed dynamically — see `.github/count-manifest.json`.
 
-| Domain          | Grade | Status                                                                  | Next Action                                     |
-| --------------- | ----- | ----------------------------------------------------------------------- | ----------------------------------------------- |
-| Agents          | A-    | 16 primary + 7 subagents; e2e-orchestrator body 430 lines (>400 limit)  | Extract e2e-orchestrator sections to references |
-| Skills          | A     | 47 skills; all lint clean; references and canary markers present        | Monitor via `lint:skills-format`                |
-| Instructions    | A     | 26 instructions; 0 orphaned refs; all applyTo globs have matching files | Monitor via `lint:glob-audit`                   |
-| Infrastructure  | A-    | Bicep + Terraform merged; IaC content archived as .tar.gz (by design)   | Expand Terraform E2E templates when needed      |
-| Documentation   | A     | Docs fresh; no stale files; lint:md 0 errors; freshness report clean    | Run doc-gardening after structural changes      |
-| CI / Validation | A     | Core repo lint clean; drawio-mcp-server suppressed via local config     | Monitor via `lint:md`                           |
-| Context Budget  | A     | Agents -18%, Skills -46%, Instructions -32% vs baseline (stable)        | Quarterly audit via AGENTS.md checklist         |
-| Backlog         | A-    | 3 active items: e2e-orchestrator body, model drift, E2E lessons         | Triage e2e-orchestrator body extraction         |
+| Domain          | Grade | Status                                                                  | Next Action                                |
+| --------------- | ----- | ----------------------------------------------------------------------- | ------------------------------------------ |
+| Agents          | A     | 16 primary + 7 subagents; all pass structural + model-prompt checks     | Monitor via `validate:agents`              |
+| Skills          | A     | 47 skills; all lint clean; references and canary markers present        | Monitor via `lint:skills-format`           |
+| Instructions    | A     | 26 instructions; 0 orphaned refs; all applyTo globs have matching files | Monitor via `lint:glob-audit`              |
+| Infrastructure  | A-    | Bicep + Terraform merged; IaC content archived as .tar.gz (by design)   | Expand Terraform E2E templates when needed |
+| Documentation   | A     | Docs fresh; no stale files; lint:md 0 errors; freshness report clean    | Run doc-gardening after structural changes |
+| CI / Validation | A     | Core repo lint clean; drawio-mcp-server suppressed via local config     | Monitor via `lint:md`                      |
+| Context Budget  | A     | Agents -18%, Skills -46%, Instructions -32% vs baseline (stable)        | Quarterly audit via AGENTS.md checklist    |
+| Backlog         | A     | 1 active item: E2E lessons                                              | Monitor E2E improvements                   |
 
 ## Grading Scale
 
@@ -26,90 +26,97 @@
 
 ## Change Log
 
-| Date       | Domain          | Change                                                                                               |
-| ---------- | --------------- | ---------------------------------------------------------------------------------------------------- |
-| 2026-02-26 | All             | Initial QUALITY_SCORE.md created; doc-gardening workflow adopted                                     |
-| 2026-02-26 | Infrastructure  | Terraform track (tf-dev): 3 agents + 3 subagents + Terraform CodeGen                                 |
-| 2026-02-26 | Skills          | terraform-patterns skill added; microsoft-\* skills added                                            |
-| 2026-02-26 | Documentation   | Doc-gardening run: 7 debt items resolved; all count references now accurate                          |
-| 2026-02-26 | Skills          | Skills grade upgraded A- → A: all 14 confirmed valid GA; 15th-folder false alarm closed              |
-| 2026-02-26 | Agents          | New debt item: 4 agents have `agents` frontmatter field as string (should be array)                  |
-| 2026-03-02 | Skills          | Skills count 14 → 17: `session-resume`, `context-optimizer`, `golden-principles` added               |
-| 2026-03-02 | Agents          | Agent count corrected 13 → 14 primary (context-optimizer agent was undercounted)                     |
-| 2026-03-02 | CI / Validation | Added `validate:session-state` script; validator count 14 → 15                                       |
-| 2026-03-02 | Documentation   | Fixed docs/README.md skill counts (16 → 17); added `session-resume` to skills table                  |
-| 2026-03-02 | Documentation   | Grade upgraded A- → A: all counts now accurate after gardening fix                                   |
-| 2026-03-02 | Instructions    | Instruction count corrected 25 → 26                                                                  |
-| 2026-03-04 | Context Budget  | M1: Agents -15%, Skills -20%, Instructions -32%; 43 on-demand reference files                        |
-| 2026-03-04 | CI / Validation | M2: 5 context-optimization validators added; validator count 15 → 22                                 |
-| 2026-03-04 | Skills          | M2: 5 skills split (session-resume, terraform-patterns, azure-bicep-patterns, etc.)                  |
-| 2026-03-04 | Agents          | M2: 3 subagents trimmed; iac-common skill created; golden-principles integrated                      |
-| 2026-03-04 | Agents          | M3: Fast-path conductor created; challenger model → Sonnet 4.6; agent count 14 → 15                  |
-| 2026-03-04 | Documentation   | M3: Weekly freshness cron workflow; quarterly context audit checklist                                |
-| 2026-03-04 | Context Budget  | M3 FINAL: Agents -18%, Skills -46%, Instructions -32%; 60 on-demand reference files                  |
-| 2026-03-04 | CI / Validation | Doc-gardening: validator count corrected 22 → 33                                                     |
-| 2026-03-04 | Backlog         | Doc-gardening: debt #10 updated (5 agents); debt #11 updated (4 warnings, new set)                   |
-| 2026-03-04 | Infrastructure  | tf-dev merged; IaC archived as .tar.gz (by design); grade B+ → A-; debt #6 resolved                  |
-| 2026-03-06 | Skills          | Skills count corrected 18 → 20: `workflow-engine` and `context-shredding` were missing from docs     |
-| 2026-03-06 | Documentation   | docs/README.md skill counts updated (18 → 20) in 3 locations; 2 skills added to table                |
-| 2026-03-06 | Backlog         | Debt #5 resolved: validate:terraform runs clean (IaC archived, zero projects expected)               |
-| 2026-03-11 | Skills          | 3 microsoft-\* skills removed (PR chore/remove-microsoft-learn-mcp); count 20 → 18                   |
-| 2026-03-11 | Skills          | Docs updated: 14 skills split with references/ (was 10); 69 on-demand reference files (was 60)       |
-| 2026-03-11 | Agents          | Count updated: 16 primary (+1: 04g-governance), 11 subagents (+2 challenger reviewers)               |
-| 2026-03-11 | Agents          | Grade A → A-: 01-orchestrator.agent.md is 354 lines (>350 limit); validate:agent-body-size failing   |
-| 2026-03-11 | CI / Validation | Grade A+ → A: validate:agent-body-size has 1 error (conductor body 354 lines)                        |
-| 2026-03-11 | Backlog         | Debt #10 updated: 7 agents now have frontmatter array warning (was 5)                                |
-| 2026-03-11 | Backlog         | New debt #14: 01-orchestrator.agent.md body 354 lines exceeds 350-line limit                         |
-| 2026-03-15 | All             | Comprehensive validation: count-manifest.json created as single source of truth for entity counts    |
-| 2026-03-15 | CI / Validation | New validator: `validate:no-hardcoded-counts` — detects hard-coded entity counts in prose            |
-| 2026-03-15 | Skills          | New skill: `count-registry` — provides canonical count phrasing for agents; 39 total skills          |
-| 2026-03-15 | Instructions    | New instruction: `no-hardcoded-counts.instructions.md` — prevents count anti-pattern; 26 total       |
-| 2026-03-15 | Documentation   | Purged 78 hard-coded counts across 37 files; all entity references now use descriptive language      |
-| 2026-03-15 | Documentation   | Resolved "7 steps" vs "8 steps" conflict: all references now say "multi-step workflow"               |
-| 2026-03-15 | Agents          | Grade A- → A: conductor body 228 lines, well under 400-line validator limit; debt #14 resolved       |
-| 2026-03-15 | Backlog         | Debt #14 resolved (conductor body within limits); 1 remaining: lint:md plugin files (accepted)       |
-| 2026-03-11 | Documentation   | Grade A → A-: 15 doc pages had stale 7-step refs, agent/skill counts; all corrected                  |
-| 2026-03-11 | Instructions    | Count corrected 26 → 27                                                                              |
-| 2026-03-11 | CI / Validation | Validator count corrected 33 → 35 (distinct lint: + validate: scripts)                               |
-| 2026-03-11 | Context Budget  | Ref files corrected 60 → 69                                                                          |
-| 2026-03-11 | Backlog         | Active debt items 2 → 3 (added #14)                                                                  |
-| 2026-03-15 | Skills          | Skills count 18 → 38: 20 Azure skills integrated (azure-skills plugin #240-#245)                     |
-| 2026-03-15 | Skills          | Ref files 69 → 834; skills with refs 14 → 32; grade A → A- (19 missing Reference Index)              |
-| 2026-03-15 | Instructions    | Instruction count corrected 27 → 25                                                                  |
-| 2026-03-15 | CI / Validation | Validator count 35 → 46; lint:md failing on 3 SKILL.minimal.md files                                 |
-| 2026-03-15 | CI / Validation | Grade A → A-: markdown lint errors in microsoft-foundry, terraform-patterns, workflow-engine         |
-| 2026-03-15 | Documentation   | Grade A- → A: all docs updated within 15 days; no stale files                                        |
-| 2026-03-15 | Agents          | Orchestrator body 354 → 363 lines; 2 codegen agents have absolute-language warnings                  |
-| 2026-03-15 | Backlog         | Debt #11 resolved (glob audit now clean); debt #15 added (markdown lint); #10 updated (8 agents)     |
-| 2026-03-15 | All             | Stale ref fixed: CHANGELOG.md `azure-troubleshooting` → `azure-diagnostics`                          |
-| 2026-03-23 | All             | Doc-gardening run: all checks pass; no stale files; freshness report clean                           |
-| 2026-03-23 | Agents          | Orchestrator body 363 → 337 lines; debt #14 resolved; 3 registry model-mismatch warnings found       |
-| 2026-03-23 | Skills          | Skills count 40 → 43; ref files 834 → 508; 19 orphaned skills (plugin architecture, by design)       |
-| 2026-03-23 | Instructions    | Instruction count 25 → 28 (3 new); all applyTo globs have matching files                             |
-| 2026-03-23 | CI / Validation | Grade A → A-: 34 validators; lint:md 115 errors in demo (96) + tests (11) + 4 site docs              |
-| 2026-03-23 | CI / Validation | SKILL.md lint errors resolved (debt #17); demo content now the primary lint debt                     |
-| 2026-03-23 | Backlog         | Debt #14 resolved (conductor 337 lines); #17 resolved (no SKILL.md lint errors)                      |
-| 2026-03-23 | Backlog         | New debt #18 (registry model drift, 3 agents), #19 (demo content lint, 96 errors)                    |
-| 2026-03-25 | Skills          | Ref files 508 → 474 (orphan cleanup); new enterprise-reference-example added to azure-diagrams       |
-| 2026-03-25 | Skills          | azure-diagrams skill: cross-step visual continuity section + curated reference example added         |
-| 2026-03-25 | CI / Validation | Grade A- → A: lint:md dropped from 115 errors to 2 (Fabric icon ref blanks only)                     |
-| 2026-03-25 | Backlog         | Debt #19 resolved (demo lint excluded or fixed); grade A- → A                                        |
-| 2026-03-25 | Backlog         | New debt #20: Fabric icon reference.md has 2 blank-line lint errors (MD012)                          |
-| 2026-03-27 | Skills          | Drawio SKILL.md: Reference Index section added; 3 canary markers added; ref files 473 total          |
-| 2026-03-27 | Skills          | Excalidraw references cleaned: 2 orphaned files removed (migrated to drawio); 1 ref remaining        |
-| 2026-03-27 | Agents          | 08-as-built.agent.md: ordered list numbering fixed (MD029)                                           |
-| 2026-03-27 | CI / Validation | Core repo lint clean (0 errors); 91 lint errors in vendored `mcp/drawio-mcp-server/` only            |
-| 2026-03-27 | CI / Validation | Freshness check: 0 issues (was 5); all canary markers and Reference Index sections present           |
-| 2026-03-27 | Instructions    | All instruction checks pass: 65 checks, 0 errors, 0 warnings                                         |
-| 2026-03-27 | Backlog         | Debt #20 resolved (Fabric ref blanks no longer flagged); drawio-mcp-server lint added as #21         |
-| 2026-04-03 | Agents          | Grade A → A-: e2e-orchestrator body 430 lines (>400 limit after E2E lessons edits)                   |
-| 2026-04-03 | CI / Validation | Grade A → A-: drawio-mcp-server lint 91 → 314 errors (third-party content growth)                    |
-| 2026-04-03 | Skills          | Skills count 43 → 47; all lint clean; 2 prompt model-mismatch warnings remain                        |
-| 2026-04-03 | Instructions    | 26 instructions; all checks pass (58 checks, 0 errors)                                               |
-| 2026-04-03 | Backlog         | Grade A → A-: new debt #22 (e2e-orchestrator body size), #23 (E2E lessons improvements)              |
-| 2026-04-03 | Backlog         | Debt #18 updated: model-mismatch now 2 prompt warnings (governance/diagnose registry drift resolved) |
-| 2026-04-03 | CI / Validation | Grade A- → A: debt #21 resolved; local .markdownlint-cli2.jsonc suppresses vendored drawio rules     |
-| 2026-04-03 | Backlog         | Debt #21 resolved; active items 4 → 3                                                                |
+| Date       | Domain          | Change                                                                                                            |
+| ---------- | --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 2026-02-26 | All             | Initial QUALITY_SCORE.md created; doc-gardening workflow adopted                                                  |
+| 2026-02-26 | Infrastructure  | Terraform track (tf-dev): 3 agents + 3 subagents + Terraform CodeGen                                              |
+| 2026-02-26 | Skills          | terraform-patterns skill added; microsoft-\* skills added                                                         |
+| 2026-02-26 | Documentation   | Doc-gardening run: 7 debt items resolved; all count references now accurate                                       |
+| 2026-02-26 | Skills          | Skills grade upgraded A- → A: all 14 confirmed valid GA; 15th-folder false alarm closed                           |
+| 2026-02-26 | Agents          | New debt item: 4 agents have `agents` frontmatter field as string (should be array)                               |
+| 2026-03-02 | Skills          | Skills count 14 → 17: `session-resume`, `context-optimizer`, `golden-principles` added                            |
+| 2026-03-02 | Agents          | Agent count corrected 13 → 14 primary (context-optimizer agent was undercounted)                                  |
+| 2026-03-02 | CI / Validation | Added `validate:session-state` script; validator count 14 → 15                                                    |
+| 2026-03-02 | Documentation   | Fixed docs/README.md skill counts (16 → 17); added `session-resume` to skills table                               |
+| 2026-03-02 | Documentation   | Grade upgraded A- → A: all counts now accurate after gardening fix                                                |
+| 2026-03-02 | Instructions    | Instruction count corrected 25 → 26                                                                               |
+| 2026-03-04 | Context Budget  | M1: Agents -15%, Skills -20%, Instructions -32%; 43 on-demand reference files                                     |
+| 2026-03-04 | CI / Validation | M2: 5 context-optimization validators added; validator count 15 → 22                                              |
+| 2026-03-04 | Skills          | M2: 5 skills split (session-resume, terraform-patterns, azure-bicep-patterns, etc.)                               |
+| 2026-03-04 | Agents          | M2: 3 subagents trimmed; iac-common skill created; golden-principles integrated                                   |
+| 2026-03-04 | Agents          | M3: Fast-path conductor created; challenger model → Sonnet 4.6; agent count 14 → 15                               |
+| 2026-03-04 | Documentation   | M3: Weekly freshness cron workflow; quarterly context audit checklist                                             |
+| 2026-03-04 | Context Budget  | M3 FINAL: Agents -18%, Skills -46%, Instructions -32%; 60 on-demand reference files                               |
+| 2026-03-04 | CI / Validation | Doc-gardening: validator count corrected 22 → 33                                                                  |
+| 2026-03-04 | Backlog         | Doc-gardening: debt #10 updated (5 agents); debt #11 updated (4 warnings, new set)                                |
+| 2026-03-04 | Infrastructure  | tf-dev merged; IaC archived as .tar.gz (by design); grade B+ → A-; debt #6 resolved                               |
+| 2026-03-06 | Skills          | Skills count corrected 18 → 20: `workflow-engine` and `context-shredding` were missing from docs                  |
+| 2026-03-06 | Documentation   | docs/README.md skill counts updated (18 → 20) in 3 locations; 2 skills added to table                             |
+| 2026-03-06 | Backlog         | Debt #5 resolved: validate:terraform runs clean (IaC archived, zero projects expected)                            |
+| 2026-03-11 | Skills          | 3 microsoft-\* skills removed (PR chore/remove-microsoft-learn-mcp); count 20 → 18                                |
+| 2026-03-11 | Skills          | Docs updated: 14 skills split with references/ (was 10); 69 on-demand reference files (was 60)                    |
+| 2026-03-11 | Agents          | Count updated: 16 primary (+1: 04g-governance), 11 subagents (+2 challenger reviewers)                            |
+| 2026-03-11 | Agents          | Grade A → A-: 01-orchestrator.agent.md is 354 lines (>350 limit); validate:agent-body-size failing                |
+| 2026-03-11 | CI / Validation | Grade A+ → A: validate:agent-body-size has 1 error (conductor body 354 lines)                                     |
+| 2026-03-11 | Backlog         | Debt #10 updated: 7 agents now have frontmatter array warning (was 5)                                             |
+| 2026-03-11 | Backlog         | New debt #14: 01-orchestrator.agent.md body 354 lines exceeds 350-line limit                                      |
+| 2026-03-15 | All             | Comprehensive validation: count-manifest.json created as single source of truth for entity counts                 |
+| 2026-03-15 | CI / Validation | New validator: `validate:no-hardcoded-counts` — detects hard-coded entity counts in prose                         |
+| 2026-03-15 | Skills          | New skill: `count-registry` — provides canonical count phrasing for agents; 39 total skills                       |
+| 2026-03-15 | Instructions    | New instruction: `no-hardcoded-counts.instructions.md` — prevents count anti-pattern; 26 total                    |
+| 2026-03-15 | Documentation   | Purged 78 hard-coded counts across 37 files; all entity references now use descriptive language                   |
+| 2026-03-15 | Documentation   | Resolved "7 steps" vs "8 steps" conflict: all references now say "multi-step workflow"                            |
+| 2026-03-15 | Agents          | Grade A- → A: conductor body 228 lines, well under 400-line validator limit; debt #14 resolved                    |
+| 2026-03-15 | Backlog         | Debt #14 resolved (conductor body within limits); 1 remaining: lint:md plugin files (accepted)                    |
+| 2026-03-11 | Documentation   | Grade A → A-: 15 doc pages had stale 7-step refs, agent/skill counts; all corrected                               |
+| 2026-03-11 | Instructions    | Count corrected 26 → 27                                                                                           |
+| 2026-03-11 | CI / Validation | Validator count corrected 33 → 35 (distinct lint: + validate: scripts)                                            |
+| 2026-03-11 | Context Budget  | Ref files corrected 60 → 69                                                                                       |
+| 2026-03-11 | Backlog         | Active debt items 2 → 3 (added #14)                                                                               |
+| 2026-03-15 | Skills          | Skills count 18 → 38: 20 Azure skills integrated (azure-skills plugin #240-#245)                                  |
+| 2026-03-15 | Skills          | Ref files 69 → 834; skills with refs 14 → 32; grade A → A- (19 missing Reference Index)                           |
+| 2026-03-15 | Instructions    | Instruction count corrected 27 → 25                                                                               |
+| 2026-03-15 | CI / Validation | Validator count 35 → 46; lint:md failing on 3 SKILL.minimal.md files                                              |
+| 2026-03-15 | CI / Validation | Grade A → A-: markdown lint errors in microsoft-foundry, terraform-patterns, workflow-engine                      |
+| 2026-03-15 | Documentation   | Grade A- → A: all docs updated within 15 days; no stale files                                                     |
+| 2026-03-15 | Agents          | Orchestrator body 354 → 363 lines; 2 codegen agents have absolute-language warnings                               |
+| 2026-03-15 | Backlog         | Debt #11 resolved (glob audit now clean); debt #15 added (markdown lint); #10 updated (8 agents)                  |
+| 2026-03-15 | All             | Stale ref fixed: CHANGELOG.md `azure-troubleshooting` → `azure-diagnostics`                                       |
+| 2026-03-23 | All             | Doc-gardening run: all checks pass; no stale files; freshness report clean                                        |
+| 2026-03-23 | Agents          | Orchestrator body 363 → 337 lines; debt #14 resolved; 3 registry model-mismatch warnings found                    |
+| 2026-03-23 | Skills          | Skills count 40 → 43; ref files 834 → 508; 19 orphaned skills (plugin architecture, by design)                    |
+| 2026-03-23 | Instructions    | Instruction count 25 → 28 (3 new); all applyTo globs have matching files                                          |
+| 2026-03-23 | CI / Validation | Grade A → A-: 34 validators; lint:md 115 errors in demo (96) + tests (11) + 4 site docs                           |
+| 2026-03-23 | CI / Validation | SKILL.md lint errors resolved (debt #17); demo content now the primary lint debt                                  |
+| 2026-03-23 | Backlog         | Debt #14 resolved (conductor 337 lines); #17 resolved (no SKILL.md lint errors)                                   |
+| 2026-03-23 | Backlog         | New debt #18 (registry model drift, 3 agents), #19 (demo content lint, 96 errors)                                 |
+| 2026-03-25 | Skills          | Ref files 508 → 474 (orphan cleanup); new enterprise-reference-example added to azure-diagrams                    |
+| 2026-03-25 | Skills          | azure-diagrams skill: cross-step visual continuity section + curated reference example added                      |
+| 2026-03-25 | CI / Validation | Grade A- → A: lint:md dropped from 115 errors to 2 (Fabric icon ref blanks only)                                  |
+| 2026-03-25 | Backlog         | Debt #19 resolved (demo lint excluded or fixed); grade A- → A                                                     |
+| 2026-03-25 | Backlog         | New debt #20: Fabric icon reference.md has 2 blank-line lint errors (MD012)                                       |
+| 2026-03-27 | Skills          | Drawio SKILL.md: Reference Index section added; 3 canary markers added; ref files 473 total                       |
+| 2026-03-27 | Skills          | Excalidraw references cleaned: 2 orphaned files removed (migrated to drawio); 1 ref remaining                     |
+| 2026-03-27 | Agents          | 08-as-built.agent.md: ordered list numbering fixed (MD029)                                                        |
+| 2026-03-27 | CI / Validation | Core repo lint clean (0 errors); 91 lint errors in vendored `mcp/drawio-mcp-server/` only                         |
+| 2026-03-27 | CI / Validation | Freshness check: 0 issues (was 5); all canary markers and Reference Index sections present                        |
+| 2026-03-27 | Instructions    | All instruction checks pass: 65 checks, 0 errors, 0 warnings                                                      |
+| 2026-03-27 | Backlog         | Debt #20 resolved (Fabric ref blanks no longer flagged); drawio-mcp-server lint added as #21                      |
+| 2026-04-03 | Agents          | Grade A → A-: e2e-orchestrator body 430 lines (>400 limit after E2E lessons edits)                                |
+| 2026-04-03 | CI / Validation | Grade A → A-: drawio-mcp-server lint 91 → 314 errors (third-party content growth)                                 |
+| 2026-04-03 | Skills          | Skills count 43 → 47; all lint clean; 2 prompt model-mismatch warnings remain                                     |
+| 2026-04-03 | Instructions    | 26 instructions; all checks pass (58 checks, 0 errors)                                                            |
+| 2026-04-03 | Backlog         | Grade A → A-: new debt #22 (e2e-orchestrator body size), #23 (E2E lessons improvements)                           |
+| 2026-04-03 | Backlog         | Debt #18 updated: model-mismatch now 2 prompt warnings (governance/diagnose registry drift resolved)              |
+| 2026-04-03 | CI / Validation | Grade A- → A: debt #21 resolved; local .markdownlint-cli2.jsonc suppresses vendored drawio rules                  |
+| 2026-04-03 | Backlog         | Debt #21 resolved; active items 4 → 3                                                                             |
+| 2026-04-12 | Agents          | Model assignments updated for 9 agents/subagents (codegen/deploy → GPT-5.4, design/subagents → Claude Sonnet 4.6) |
+| 2026-04-12 | Backlog         | Debt #18 resolved: 0 prompt model-mismatch warnings remain (orchestrator + design prompts fixed)                  |
+| 2026-04-12 | Backlog         | Active items 3 → 2: e2e-orchestrator body, E2E lessons                                                            |
+| 2026-04-12 | Documentation   | Doc-gardening: 4 terminology errors fixed in `site/src/content/docs/reference/resources.md`                       |
+| 2026-04-12 | Instructions    | `agent-definitions.instructions.md` prose + table model drift fixed (challenger, codegen, design)                 |
+| 2026-04-12 | Agents          | Grade A- → A: e2e-orchestrator 425 lines under new 500-line limit; all validators pass                            |
+| 2026-04-12 | Backlog         | Debt #22 resolved (body limit raised to 500); active items 2 → 1                                                  |
 
 ## How to Update
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] — Unreleased
 
+### Changed
+
+- feat(agents): update model assignments for 9 agents/subagents.
+  Codegen agents (06b-Bicep CodeGen, 06t-Terraform CodeGen) and deploy agents
+  (07b-Bicep Deploy, 07t-Terraform Deploy) move from Claude Sonnet 4.6 → GPT-5.4.
+  Design agent (04-Design) moves from GPT-5.4 → Claude Sonnet 4.6.
+  Validation subagents (bicep-validate, bicep-whatif, terraform-validate, terraform-plan)
+  move from GPT-5.4 → Claude Sonnet 4.6.
+  Body content rewritten per model conventions: XML semantic blocks converted to markdown
+  headings for GPT-5.4 agents; Claude XML blocks added to 04-Design.
+  DO/DON'T tables converted to heading+list format for GPT-5.4 agents.
+- fix(agents): resolve Debt #18 — fix 2 orchestrator prompt model mismatches
+  (`01-orchestrator.prompt.md` and `resume-workflow.prompt.md` now match agent frontmatter).
+- refactor(docs): remove hardcoded model names from challenger-review-subagent references
+  in 03-architect body, docs, and skill reference files. Model is now sourced from
+  subagent frontmatter only.
+- chore(scripts): raise MAX_BODY_LINES from 400 → 500 in `scripts/_lib/paths.mjs`.
+
 ### Added
 
 - feat(drawio): replace jgraph `@drawio/mcp@1.1.1` with simonkurtz-MSFT `drawio-mcp-server` v3.0.1

--- a/docs/architecture-explorer.html
+++ b/docs/architecture-explorer.html
@@ -396,7 +396,7 @@
         "01-Orchestrator-FastPath": { model: "Claude Sonnet 4.6", step: null },
         "02-Requirements": { model: "Claude Opus 4.6", step: 1 },
         "03-Architect": { model: "Claude Opus 4.6", step: 2 },
-        "04-Design": { model: "GPT-5.4", step: 3 },
+        "04-Design": { model: "Claude Sonnet 4.6", step: 3 },
         "04g-Governance": { model: "GPT-5.4", step: 3.5 },
         "05-IaC Planner": { model: "Claude Opus 4.6", step: 4 },
         "06b-Bicep CodeGen": { model: "GPT-5.4", step: 5 },

--- a/docs/how-it-works/agents.md
+++ b/docs/how-it-works/agents.md
@@ -106,7 +106,7 @@ It operates with rotating lenses:
 
 !!! info "Challenger Selection Rules"
 
-    Pass 1 (security-governance) always uses `challenger-review-subagent` (GPT-5.4).
+    Pass 1 (security-governance) always uses `challenger-review-subagent`.
     Additional passes also use `challenger-review-subagent` for
     architecture-reliability and cost-feasibility lenses.
     See `.github/skills/azure-defaults/references/challenger-selection-rules.md`

--- a/scripts/_lib/paths.mjs
+++ b/scripts/_lib/paths.mjs
@@ -16,6 +16,6 @@ export const REGISTRY_PATH = ".github/agent-registry.json";
 export const AFFINITY_PATH = ".github/skill-affinity.json";
 export const COPILOT_INSTRUCTIONS = ".github/copilot-instructions.md";
 
-export const MAX_BODY_LINES = 400;
+export const MAX_BODY_LINES = 500;
 export const MAX_SKILL_LINES_WITHOUT_REFS = 200;
 export const MAX_LINES_WITH_WILDCARD = 50;

--- a/site/public/architecture-explorer.html
+++ b/site/public/architecture-explorer.html
@@ -359,7 +359,7 @@
         "01-Orchestrator-FastPath": { model: "Claude Sonnet 4.6", step: null },
         "02-Requirements": { model: "Claude Opus 4.6", step: 1 },
         "03-Architect": { model: "Claude Opus 4.6", step: 2 },
-        "04-Design": { model: "GPT-5.4", step: 3 },
+        "04-Design": { model: "Claude Sonnet 4.6", step: 3 },
         "04g-Governance": { model: "GPT-5.4", step: 3.5 },
         "05-IaC Planner": { model: "Claude Opus 4.6", step: 4 },
         "06b-Bicep CodeGen": { model: "GPT-5.4", step: 5 },

--- a/site/src/content/docs/concepts/how-it-works/agents.md
+++ b/site/src/content/docs/concepts/how-it-works/agents.md
@@ -12,14 +12,14 @@ Every agent definition follows a standard structure:
 ---
 name: 06b-Bicep CodeGen
 description: Expert Azure Bicep IaC specialist...
-model: ["Claude Opus (latest)"] # (1)!
+model: ["GPT-5.4"] # (1)!
 tools: [list of allowed tools] # (2)!
 handoffs:
   - label: "Step 6: Deploy"
     agent: 07b-Bicep Deploy # (3)!
     prompt: "Deploy the Bicep templates..."
 ---
-# Body (≤ 350 lines)
+# Body (≤ 500 lines)
 ## MANDATORY: Read Skills First
 1. **Read** `.github/skills/azure-defaults/SKILL.md` # (4)!
 2. **Read** `.github/skills/azure-artifacts/SKILL.md`
@@ -54,23 +54,23 @@ and routing to the next step. At approval gates, the Orchestrator writes a
 
 ## Top-Level Agents
 
-| Agent                    | Role                                            | Primary Skills                                 |
-| ------------------------ | ----------------------------------------------- | ---------------------------------------------- |
+| Agent                       | Role                                            | Primary Skills                                 |
+| --------------------------- | ----------------------------------------------- | ---------------------------------------------- |
 | 01-Orchestrator             | Master orchestrator                             | workflow-engine, session-resume                |
 | 01-Orchestrator (Fast Path) | Simplified path for ≤3 resources                | session-resume, azure-defaults                 |
-| 02-Requirements          | Captures project requirements                   | azure-defaults, azure-artifacts                |
-| 03-Architect             | WAF assessment and cost estimation              | azure-defaults                                 |
-| 04-Design                | Diagrams and ADRs                               | drawio, python-diagrams, azure-adr             |
-| 04g-Governance           | Policy discovery and compliance                 | azure-defaults                                 |
-| 05-IaC Planner           | IaC implementation planning (Bicep & Terraform) | azure-bicep-patterns, terraform-patterns       |
-| 06b-Bicep CodeGen        | Bicep template generation                       | azure-bicep-patterns                           |
-| 06t-Terraform CodeGen    | Terraform configuration generation              | terraform-patterns                             |
-| 07b-Bicep Deploy         | Bicep deployment execution                      | azure-validate, iac-common                     |
-| 07t-Terraform Deploy     | Terraform deployment execution                  | azure-validate, iac-common, terraform-patterns |
-| 08-As-Built              | Post-deployment documentation                   | azure-artifacts, drawio, python-diagrams       |
-| 09-Diagnose              | Azure resource troubleshooting                  | azure-diagnostics                              |
-| 10-Challenger            | Standalone adversarial review                   | —                                              |
-| 11-Context Optimizer     | Context window audit and optimisation           | context-optimizer                              |
+| 02-Requirements             | Captures project requirements                   | azure-defaults, azure-artifacts                |
+| 03-Architect                | WAF assessment and cost estimation              | azure-defaults                                 |
+| 04-Design                   | Diagrams and ADRs                               | drawio, python-diagrams, azure-adr             |
+| 04g-Governance              | Policy discovery and compliance                 | azure-defaults                                 |
+| 05-IaC Planner              | IaC implementation planning (Bicep & Terraform) | azure-bicep-patterns, terraform-patterns       |
+| 06b-Bicep CodeGen           | Bicep template generation                       | azure-bicep-patterns                           |
+| 06t-Terraform CodeGen       | Terraform configuration generation              | terraform-patterns                             |
+| 07b-Bicep Deploy            | Bicep deployment execution                      | azure-validate, iac-common                     |
+| 07t-Terraform Deploy        | Terraform deployment execution                  | azure-validate, iac-common, terraform-patterns |
+| 08-As-Built                 | Post-deployment documentation                   | azure-artifacts, drawio, python-diagrams       |
+| 09-Diagnose                 | Azure resource troubleshooting                  | azure-diagnostics                              |
+| 10-Challenger               | Standalone adversarial review                   | —                                              |
+| 11-Context Optimizer        | Context window audit and optimisation           | context-optimizer                              |
 
 ## Subagents
 
@@ -85,7 +85,7 @@ specific tasks:
 | bicep-validate-subagent       | Lint + AVM/security code review     | Step 5 (Bicep)      |
 | bicep-whatif-subagent         | `az deployment what-if` preview     | Step 6 (Bicep)      |
 | terraform-validate-subagent   | Lint + AVM-TF/security code review  | Step 5 (Terraform)  |
-| iac-planner-subagent       | `terraform plan` preview            | Step 6 (Terraform)  |
+| terraform-plan-subagent       | `terraform plan` preview            | Step 6 (Terraform)  |
 
 ## The Challenger Pattern
 
@@ -98,7 +98,7 @@ The `challenger-review-subagent` implements adversarial review at critical workf
 It operates with rotating lenses:
 
 :::note[Challenger Selection Rules]
-Pass 1 (security-governance) always uses `challenger-review-subagent` (GPT-5.4).
+Pass 1 (security-governance) always uses `challenger-review-subagent`.
 Additional passes also use `challenger-review-subagent` for
 architecture-reliability and cost-feasibility lenses.
 See `.github/skills/azure-defaults/references/challenger-selection-rules.md`
@@ -180,11 +180,13 @@ This section walks through creating a new agent from scratch.
 | Top-level agent | `.github/agents/{name}.agent.md`            | Yes            | User-facing workflow steps                |
 | Subagent        | `.github/agents/_subagents/{name}.agent.md` | No             | Isolated tasks delegated by parent agents |
 
-Model selection depends on the task:
+Model selection depends on the task. Use `.github/agent-registry.json` as the
+source of truth, but the current repo pattern is:
 
-- **Planning agents** (accuracy-first) — use `Claude Opus (latest)`
-- **Execution subagents** (speed) — check `.github/agent-registry.json` for current assignments
-- **Adversarial review** — use a different model family than the artifact author
+- **Planning agents** (accuracy-first) — typically `Claude Opus 4.6`
+- **Execution and deploy agents** — typically `GPT-5.4`
+- **Validation and preview subagents** — currently `Claude Sonnet 4.6`
+- **Adversarial review** — use a different model family than the artifact author when possible
 
 ### Step 2: Create the Agent File
 
@@ -197,7 +199,7 @@ description: >-
   One-line description of what this agent does.
   USE FOR: keyword triggers. DO NOT USE FOR: anti-triggers.
 model:
-  - Claude Opus (latest)
+  - GPT-5.4
 tools:
   - read_file
   - create_file

--- a/site/src/content/docs/concepts/how-it-works/index.mdx
+++ b/site/src/content/docs/concepts/how-it-works/index.mdx
@@ -66,6 +66,16 @@ are enforced as first-class concerns across all generated infrastructure.
   />
 </CardGrid>
 
+## Recommended Reading Order
+
+If you are new to APEX, read the docs in this order:
+
+1. [System Architecture](architecture/) for the overall flow
+2. [Agent Architecture](agents/) for roles, handoffs, and subagents
+3. [Skills & Instructions](skills-and-instructions/) for the knowledge and rule layers
+4. [Workflow Engine & Quality](workflow-engine/) for gates, validation, and session state
+5. [MCP Integration](mcp-integration/) for external tool access and server capabilities
+
 ## Intellectual Foundations
 
 This project draws directly from two bodies of work that define how autonomous AI agents
@@ -201,8 +211,8 @@ artefact files in `agent-output/{project}/` and the machine-readable
 **Right-sized task decomposition.** Ralph insists that each PRD item must be
 small enough to complete within a single context window — "Add a database
 column" not "Build the entire dashboard." This project enforces the same
-principle at a different scale: each of the 8 workflow steps is scoped to a
-single well-defined output (one requirements doc, one architecture assessment,
+principle at a different scale: each of the 7 main workflow steps plus Step 3.5
+Governance is scoped to a single well-defined output (one requirements doc, one architecture assessment,
 one implementation plan), and subagents are further decomposed to atomic
 validation or review tasks.
 
@@ -249,14 +259,14 @@ This project weaves all three into a system purpose-built for Azure infrastructu
 | Knowledge management   | Repo is system of record             | Shared knowledge base               | `AGENTS.md` + `progress.txt`     | Skills + instructions + `agent-output/`                       |
 | Context management     | Map, not manual                      | Context shredding                   | Fresh context per iteration      | Progressive skill loading + 3-tier compression                |
 | Quality enforcement    | Mechanical enforcement of invariants | Pre-push hooks + anomaly detection  | Mandatory CI feedback loops      | Validators + pre-commit/push hooks + Copilot hooks            |
-| Workflow orchestration | Structured step progression          | Workflow engine DAG                 | Bash loop + `prd.json` task list | `workflow-graph.json` + Orchestrator agent                       |
+| Workflow orchestration | Structured step progression          | Workflow engine DAG                 | Bash loop + `prd.json` task list | `workflow-graph.json` + Orchestrator agent                    |
 | Concurrency safety     | —                                    | Claim-based locking                 | Single-instance sequential loop  | Serial execution (v3.0 — lock/claim removed)                  |
 | Task decomposition     | —                                    | —                                   | One context window per story     | One artefact per workflow step                                |
-| Cost optimisation      | —                                    | —                                   | —                                | Model tier selection via Orchestrator                            |
+| Cost optimisation      | —                                    | —                                   | —                                | Model tier selection via Orchestrator                         |
 | Failure resilience     | —                                    | Circuit breaker + anomaly detection | CI-gated iteration               | Failure taxonomy + stopping rules                             |
 | Learning persistence   | Human taste gets encoded             | —                                   | Append-only `progress.txt`       | Skills + instructions evolve over time                        |
 | Human control          | Human taste gets encoded             | Mandatory review gates              | Max iterations cap               | 5 approval gates + challenger reviews                         |
-| Cost governance        | Enforce invariants, not impls        | —                                   | —                                | `iac-cost-repeatability` instruction + adversarial checklists |
+| Cost governance        | Enforce invariants, not impls        | —                                   | —                                | `iac-best-practices.instructions.md` + adversarial checklists |
 | Context efficiency     | Context is scarce                    | Context shredding                   | Fresh context per iteration      | Session Break Protocol at Gates 2 & 3 + conditional pass 3    |
 
 ## Golden Principles

--- a/site/src/content/docs/concepts/how-it-works/skills-and-instructions.md
+++ b/site/src/content/docs/concepts/how-it-works/skills-and-instructions.md
@@ -40,12 +40,12 @@ The system contains the following skills across several domains:
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Azure Infrastructure | `azure-defaults`, `azure-bicep-patterns`, `terraform-patterns`                                                                                                                                                                                                                                                                                                                                                      |
 | Azure Operations     | `azure-diagnostics`, `azure-adr`                                                                                                                                                                                                                                                                                                                                                                                    |
-| Diagram & Chart      | `drawio`, `excalidraw` (whiteboarding), `python-diagrams`, `mermaid`                                                                                                                                                                                                                                                                                                                                                                |
+| Diagram & Chart      | `drawio`, `excalidraw` (whiteboarding), `python-diagrams`, `mermaid`                                                                                                                                                                                                                                                                                                                                                |
 | Artefact Generation  | `azure-artifacts`, `context-shredding`                                                                                                                                                                                                                                                                                                                                                                              |
 | Documentation        | `docs-writer`                                                                                                                                                                                                                                                                                                                                                                                                       |
 | Workflow and State   | `session-resume`, `workflow-engine`, `golden-principles`                                                                                                                                                                                                                                                                                                                                                            |
 | Deployment           | `iac-common`                                                                                                                                                                                                                                                                                                                                                                                                        |
-| GitHub Operations    | `github-operations`, `git-commit`                                                                                                                                                                                                                                                                                                                                                                                   |
+| GitHub Operations    | `github-operations`                                                                                                                                                                                                                                                                                                                                                                                                 |
 | Azure Plugin Skills  | `azure-prepare`, `azure-cost-optimization`, `azure-deploy` (not active), `azure-compute`, `azure-compliance`, `azure-rbac`, `azure-storage`, `azure-messaging`, `azure-kusto`, `azure-ai`, `azure-aigateway`, `azure-quotas`, `azure-resource-lookup`, `azure-resource-visualizer`, `azure-cloud-migrate`, `azure-hosted-copilot-sdk`, `appinsights-instrumentation`, `entra-app-registration`, `microsoft-foundry` |
 | Microsoft Learn      | `microsoft-docs`, `microsoft-code-reference`, `microsoft-skill-creator`                                                                                                                                                                                                                                                                                                                                             |
 | Meta / Tooling       | `make-skill-template`, `context-optimizer`, `copilot-customization`                                                                                                                                                                                                                                                                                                                                                 |
@@ -62,35 +62,29 @@ Instructions are not read explicitly by agents. They are injected automatically 
 VS Code Copilot when a matching file is in context. The `applyTo` glob pattern controls
 when each instruction activates:
 
-| Instruction                     | `applyTo`                                          | Enforces                                 |
-| ------------------------------- | -------------------------------------------------- | ---------------------------------------- |
-| `bicep-code-best-practices`     | `**/*.bicep`                                       | AVM-first, security baseline, naming     |
-| `terraform-code-best-practices` | `**/*.tf`                                          | AVM-TF, provider pinning, naming         |
-| `bicep-policy-compliance`       | `**/*.bicep`                                       | Azure Policy compliance in Bicep         |
-| `terraform-policy-compliance`   | `**/*.tf`                                          | Azure Policy compliance in Terraform     |
-| `iac-cost-repeatability`        | `**/*.bicep`, `**/*.tf`, `**/04-impl*.md`          | Budget alerts, zero hardcoded values     |
-| `azure-artifacts`               | `**/agent-output/**/*.md`                          | H2 template compliance for artefacts     |
-| `agent-definitions`             | `**/*.agent.md`                                    | Frontmatter standards for agents         |
-| `agent-research-first`          | `**/*.agent.md`, agent-output, skills              | Mandatory research-before-implementation |
-| `agent-skills`                  | `**/.github/skills/**/SKILL.md`                    | Skill file format standards              |
-| `instructions`                  | `**/*.instructions.md`                             | Meta: instruction file guidelines        |
-| `markdown`                      | `**/*.md`                                          | Documentation standards                  |
-| `context-optimization`          | Agents, skills, instructions                       | Context window management rules          |
-| `code-commenting`               | `**/*.{js,mjs,cjs,ts,tsx,jsx,py,ps1,sh,bicep,tf}`  | Self-explanatory code, minimal comments  |
-| `code-review`                   | `**/*.{js,mjs,cjs,ts,tsx,jsx,py,ps1,sh,bicep,tf}`  | Priority tiers, security checks          |
-| `cost-estimate`                 | `**/03-des-cost-estimate.md`, `**/07-ab-cost-*.md` | Cost estimate documentation standards    |
-| `docs-trigger`                  | `**/*.{js,mjs,cjs,ts,tsx,jsx,py,ps1,sh,bicep,tf}`  | Trigger conditions for doc updates       |
-| `docs`                          | `docs/**/*.md`                                     | User-facing documentation standards      |
-| `governance-discovery`          | `**/04-governance-constraints.*`                   | Azure Policy discovery requirements      |
-| `workload-documentation`        | `**/agent-output/**/07-*.md`                       | Workload documentation standards         |
-| `github-actions`                | `.github/workflows/*.yml`                          | GitHub Actions workflow standards        |
-| `javascript`                    | `**/*.{js,mjs,cjs}`                                | JavaScript/Node.js conventions           |
-| `json`                          | `**/*.{json,jsonc}`                                | JSON/JSONC formatting                    |
-| `python`                        | `**/*.py`                                          | Python coding conventions                |
-| `shell`                         | `**/*.sh`                                          | Shell scripting best practices           |
-| `powershell`                    | `**/*.ps1`, `**/*.psm1`                            | PowerShell cmdlet best practices         |
-| `prompt`                        | `**/*.prompt.md`                                   | Prompt file guidelines                   |
-| `no-heredoc`                    | `**`                                               | Prevents terminal heredoc corruption     |
+| Instruction                     | `applyTo`                                                            | Enforces                                                            |
+| ------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `iac-best-practices`            | `**/*.bicep`, `**/*.tf`, `**/04-implementation-plan.md`              | Security baseline, policy alignment, cost monitoring, repeatability |
+| `terraform-code-best-practices` | `**/*.tf`                                                            | AVM-TF, provider pinning, naming                                    |
+| `azure-artifacts`               | `**/agent-output/**/*.md`                                            | H2 template compliance for artefacts                                |
+| `agent-definitions`             | `**/*.agent.md`                                                      | Frontmatter standards for agents                                    |
+| `agent-research-first`          | `**/*.agent.md`, agent-output, skills                                | Mandatory research-before-implementation                            |
+| `agent-skills`                  | `**/.github/skills/**/SKILL.md`                                      | Skill file format standards                                         |
+| `instructions`                  | `**/*.instructions.md`                                               | Meta: instruction file guidelines                                   |
+| `markdown`                      | `**/*.md`                                                            | Documentation standards                                             |
+| `context-optimization`          | Agents, skills, instructions                                         | Context window management rules                                     |
+| `code-quality`                  | `**/*.{js,mjs,cjs,ts,tsx,jsx,py,ps1,sh,bicep,tf}`                    | Review priorities and comment quality                               |
+| `docs-trigger`                  | `**/*.agent.md`, `**/.github/skills/**/SKILL.md`, `**/scripts/*.mjs` | Trigger conditions for doc updates                                  |
+| `docs`                          | `site/src/content/docs/**/*.md`, `site/src/content/docs/**/*.mdx`    | User-facing documentation standards                                 |
+| `governance-discovery`          | `**/04-governance-constraints.*`                                     | Azure Policy discovery requirements                                 |
+| `github-actions`                | `.github/workflows/*.yml`                                            | GitHub Actions workflow standards                                   |
+| `javascript`                    | `**/*.{js,mjs,cjs}`                                                  | JavaScript/Node.js conventions                                      |
+| `json`                          | `**/*.{json,jsonc}`                                                  | JSON/JSONC formatting                                               |
+| `python`                        | `**/*.py`                                                            | Python coding conventions                                           |
+| `shell`                         | `**/*.sh`                                                            | Shell scripting best practices                                      |
+| `powershell`                    | `**/*.ps1`, `**/*.psm1`                                              | PowerShell cmdlet best practices                                    |
+| `prompt`                        | `**/*.prompt.md`                                                     | Prompt file guidelines                                              |
+| `no-heredoc`                    | `**`                                                                 | Prevents terminal heredoc corruption                                |
 
 When multiple instructions apply to the same file via overlapping `applyTo` globs,
 precedence rules determine which takes priority. See
@@ -98,8 +92,8 @@ precedence rules determine which takes priority. See
 Short version: Azure Policy compliance (Tier 1) always wins over domain IaC (Tier 2),
 which wins over cross-cutting cost rules (Tier 3), which wins over general code quality (Tier 4).
 
-**`iac-cost-repeatability`** is a cross-cutting instruction that enforces two mandatory
-rules across ALL projects (Bicep and Terraform):
+**`iac-best-practices.instructions.md`** is the cross-cutting instruction that enforces
+two mandatory rules across all IaC projects (Bicep and Terraform):
 
 1. **Cost Monitoring**: Every deployment must include an Azure Budget resource with
    parameterised amount, forecast alerts at 80/100/120% thresholds, and anomaly

--- a/site/src/content/docs/concepts/workflow.md
+++ b/site/src/content/docs/concepts/workflow.md
@@ -130,7 +130,8 @@ sequenceDiagram
 
 The Orchestrator delegates work to specialised agents in sequence.
 Shared steps (1–3.5, 7) are common; steps 4–6 diverge into **Bicep** or **Terraform** tracks.
-Each IaC Code agent invokes validation subagents (lint, whatif/plan, review).
+Code agents invoke validation subagents, and deploy agents invoke the track-specific
+preview subagents before any Azure changes are applied.
 
 <img src="/azure-agentic-infraops/images/agent-delegation-graph.png"
      width="100%" style="border-radius: 10px; margin: 1rem 0;"
@@ -141,9 +142,9 @@ Each IaC Code agent invokes validation subagents (lint, whatif/plan, review).
 
 ### Primary Orchestrator
 
-| Agent            | Codename        | Role                                        | Model                |
-| ---------------- | --------------- | ------------------------------------------- | -------------------- |
-| **Orchestrator** | 🧠 Orchestrator | Master orchestrator for multi-step workflow | Claude Opus (latest) |
+| Agent            | Codename        | Role                                        | Model   |
+| ---------------- | --------------- | ------------------------------------------- | ------- |
+| **Orchestrator** | 🧠 Orchestrator | Master orchestrator for multi-step workflow | GPT-5.4 |
 
 ### Core Agents (by Workflow Step)
 
@@ -167,17 +168,17 @@ Steps 1-3.5 and 7 are shared. Steps 4-6 have Bicep and Terraform variants.
 
 **Bicep track:**
 
-| Subagent                  | Purpose                                      | Invoked By                   |
-| ------------------------- | -------------------------------------------- | ---------------------------- |
-| `bicep-validate-subagent` | Lint + code review (AVM, security, naming)   | `bicep-code`                 |
-| `bicep-whatif-subagent`   | Deployment preview (`az deployment what-if`) | `bicep-code`, `bicep-deploy` |
+| Subagent                  | Purpose                                      | Invoked By     |
+| ------------------------- | -------------------------------------------- | -------------- |
+| `bicep-validate-subagent` | Lint + code review (AVM, security, naming)   | `bicep-code`   |
+| `bicep-whatif-subagent`   | Deployment preview (`az deployment what-if`) | `bicep-deploy` |
 
 **Terraform track:**
 
-| Subagent                      | Purpose                                       | Invoked By       |
-| ----------------------------- | --------------------------------------------- | ---------------- |
-| `terraform-validate-subagent` | Lint + code review (AVM-TF, security, naming) | `terraform-code` |
-| `iac-planner-subagent`        | Deployment preview (`terraform plan`)         | `terraform-code` |
+| Subagent                      | Purpose                                       | Invoked By         |
+| ----------------------------- | --------------------------------------------- | ------------------ |
+| `terraform-validate-subagent` | Lint + code review (AVM-TF, security, naming) | `terraform-code`   |
+| `terraform-plan-subagent`     | Deployment preview (`terraform plan`)         | `terraform-deploy` |
 
 ### Standalone Agents
 
@@ -203,6 +204,13 @@ infrastructure that violates governance policies or security baselines.
 | **Gate 3**   | Planning (Step 4)     | Approve implementation plan         |
 | **Gate 4**   | Pre-Deploy (Step 5)   | Approve lint/what-if/review results |
 | **Gate 5**   | Post-Deploy (Step 6)  | Verify deployment                   |
+
+:::tip[If a gate rejects the current output]
+If a gate or challenger review returns `must_fix` findings, go back to the
+previous workflow step, update the artifact that was challenged, and re-run that
+step. The Orchestrator regenerates the output and re-triggers the gate instead of
+skipping ahead.
+:::
 
 ## Workflow Steps
 
@@ -308,6 +316,9 @@ fails, the planner stops and requests governance refresh.
 
 **Prerequisites**: `04-governance-constraints.md/.json` from Step 3.5
 
+If governance discovery completed successfully, an empty policy array is still a
+valid input. It means no deny-effect constraints were found for the current scope.
+
 **Features**:
 
 - Governance constraints integration from Step 3.5
@@ -356,7 +367,6 @@ Both tracks also produce `agent-output/{project}/05-implementation-reference.md`
 | Bicep Subagent            | Terraform Subagent            | Validation         |
 | ------------------------- | ----------------------------- | ------------------ |
 | `bicep-validate-subagent` | `terraform-validate-subagent` | Lint + code review |
-| `bicep-whatif-subagent`   | `iac-planner-subagent`        | Deployment preview |
 
 :::note[Approval Gate]
 The user must approve preflight validation results before deployment.
@@ -367,6 +377,11 @@ The user must approve preflight validation results before deployment.
 **Agent**: `bicep-deploy` (Bicep track) or `terraform-deploy` (Terraform track)
 
 Execute Azure deployment with preflight validation.
+
+The deploy agents always run a preview before applying changes:
+
+- **Bicep** uses `bicep-whatif-subagent` for `az deployment group what-if`
+- **Terraform** uses `terraform-plan-subagent` for `terraform plan`
 
 :::caution[Pre-Deploy Security Review]
 Before deployment, the agent runs `npm run validate:iac-security-baseline`
@@ -400,16 +415,19 @@ of the what-if/plan output. Violations block deployment.
 The user must verify deployed resources before proceeding to documentation.
 :::
 
-### Step 7: Documentation (📚 Skills)
+### Step 7: Documentation (📚 Chronicler)
 
-**Skill**: `azure-artifacts`
+**Agent**: `as-built`
 
-Generate comprehensive workload documentation.
+Generate comprehensive workload documentation after deployment verification.
 
 ```text
-Trigger: "Generate documentation for {project}"
+Invoke: Ctrl+Shift+A → as-built
 Output: agent-output/{project}/07-*.md
 ```
+
+The As-Built agent uses the `azure-artifacts` skill and prior workflow artifacts
+to assemble the final documentation suite.
 
 **Document Suite**:
 

--- a/site/src/content/docs/getting-started/quickstart.md
+++ b/site/src/content/docs/getting-started/quickstart.md
@@ -31,13 +31,19 @@ when deploying to Azure in Step 6.
 | GitHub fine-grained PAT | Required for devcontainer GitHub auth via `GH_TOKEN`        |
 | VS Code                 | [Download](https://code.visualstudio.com/)                  |
 | Docker Desktop          | [Download](https://www.docker.com/products/docker-desktop/) |
-| Azure subscription      | Optional for learning                                       |
+| Azure subscription      | Required only for Step 6 deployment                         |
 
 :::note[Docker is required]
 A Docker-compatible runtime is needed for the dev container. [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 is the most common choice. Free alternatives include [Rancher Desktop](https://rancherdesktop.io/),
 [Colima](https://github.com/abiosoft/colima) (macOS), and [Podman](https://podman.io/) (Linux/macOS).
 See [Dev Container Setup](../dev-containers/) for detailed installation options.
+:::
+
+:::tip[If the dev container fails to build]
+Verify Docker is running, then follow the recovery steps in
+[Dev Container Setup](../dev-containers/) and [Troubleshooting](../../guides/troubleshooting/).
+Most setup failures happen before APEX itself starts.
 :::
 
 :::caution[Configure `GH_TOKEN` before you open the container]
@@ -151,6 +157,9 @@ az --version && bicep --version && terraform --version && pwsh --version # (1)!
 The Orchestrator pattern requires this setting.
 :::
 
+Without this setting, the Orchestrator cannot delegate to specialized agents,
+so multi-step workflows will stall after the first response.
+
 Add this to your **VS Code User Settings** (`Ctrl+,` → Settings JSON):
 
 ```json
@@ -238,6 +247,21 @@ will re-execute the step and re-trigger the gate. Use the artifact files in
 `agent-output/{project}/` to understand what was flagged.
 :::
 
+### If a Step Fails
+
+- **Governance returns no policies**: continue if `04-governance-constraints.json`
+  shows `discovery_status: "COMPLETE"`. An empty policy list means no deny-effect
+  constraints were found for that scope.
+- **Pricing, auth, or tooling fails**: fix the environment first, then resume the same step.
+  Start with [Troubleshooting](../../guides/troubleshooting/) and
+  [Dev Container Setup](../dev-containers/).
+- **Security or cost findings block progress**: update the generated plan or code,
+  then re-run the same step with the exact failing output so the agent can repair it.
+
+Before you deploy, review the mandatory guidance in
+[Security Baseline](../../guides/security-baseline/) and
+[Cost Governance](../../guides/cost-governance/).
+
 ## What You've Created
 
 After completing the workflow:
@@ -278,16 +302,17 @@ infra/terraform/my-webapp/
 
 ## Next Steps
 
-| Goal                            | Resource                                                                           |
-| ------------------------------- | ---------------------------------------------------------------------------------- |
-| Understand the full workflow    | [workflow.md](../../concepts/workflow/)                                            |
-| Try a guided hands-on challenge | [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/)          |
-| Try a complete workflow         | [Prompt Guide](../../guides/prompt-guide/)                                         |
-| Generate architecture diagrams  | Use `drawio` skill (or `python-diagrams` for charts)                               |
-| Create documentation            | Use `azure-artifacts` skill                                                        |
-| Explore Terraform patterns      | Use `terraform-patterns` skill                                                     |
-| Troubleshoot issues             | [troubleshooting.md](../../guides/troubleshooting/)                                |
-| Contribute to the upstream repo | [azure-agentic-infraops](https://github.com/jonathan-vella/azure-agentic-infraops) |
+| Goal                            | Resource                                                                                                  |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Understand the full workflow    | [workflow.md](../../concepts/workflow/)                                                                   |
+| Try a guided hands-on challenge | [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/)                                 |
+| Try a complete workflow         | [Prompt Guide](../../guides/prompt-guide/)                                                                |
+| Review mandatory guardrails     | [Security Baseline](../../guides/security-baseline/) and [Cost Governance](../../guides/cost-governance/) |
+| Generate architecture diagrams  | Use `drawio` skill (or `python-diagrams` for charts)                                                      |
+| Create documentation            | Use `azure-artifacts` skill                                                                               |
+| Explore Terraform patterns      | Use `terraform-patterns` skill                                                                            |
+| Troubleshoot issues             | [troubleshooting.md](../../guides/troubleshooting/)                                                       |
+| Contribute to the upstream repo | [azure-agentic-infraops](https://github.com/jonathan-vella/azure-agentic-infraops)                        |
 
 ## Quick Reference
 

--- a/site/src/content/docs/guides/cost-governance.md
+++ b/site/src/content/docs/guides/cost-governance.md
@@ -8,8 +8,8 @@ description: "Budget alerts, forecasts, and cost anomaly detection"
 ## Why Cost Governance Is Mandatory
 
 Every IaC deployment in this project **must** include cost monitoring resources.
-This is enforced by the `iac-cost-repeatability` instruction, which auto-applies
-to all `.bicep`, `.tf`, and implementation plan files.
+This is enforced by `iac-best-practices.instructions.md`, which applies to
+all `.bicep`, `.tf`, and implementation plan files.
 
 The rule is simple: **no budget, no merge**. Challenger reviews verify cost
 monitoring exists, and CI validators flag missing budget resources.
@@ -155,15 +155,15 @@ The **cost-estimate-subagent** uses the Azure Pricing MCP server to query
 real-time SKU pricing during architecture review (Step 2) and as-built
 documentation (Step 7). Key tools:
 
-| Tool                          | Purpose                                |
-| ----------------------------- | -------------------------------------- |
-| `azure_cost_estimate`         | Estimate costs based on usage patterns |
-| `azure_bulk_estimate`         | Multi-resource estimate in one call    |
-| `azure_price_compare`         | Compare prices across regions and SKUs |
-| `azure_ri_pricing`            | Reserved Instance pricing and savings  |
-| `azure_region_recommend`      | Find cheapest regions for a service    |
-| `find_orphaned_resources`     | Detect unused resources with cost data |
-| `azure_ptu_sizing`            | Estimate PTUs for Azure OpenAI         |
+| Tool                      | Purpose                                |
+| ------------------------- | -------------------------------------- |
+| `azure_cost_estimate`     | Estimate costs based on usage patterns |
+| `azure_bulk_estimate`     | Multi-resource estimate in one call    |
+| `azure_price_compare`     | Compare prices across regions and SKUs |
+| `azure_ri_pricing`        | Reserved Instance pricing and savings  |
+| `azure_region_recommend`  | Find cheapest regions for a service    |
+| `find_orphaned_resources` | Detect unused resources with cost data |
+| `azure_ptu_sizing`        | Estimate PTUs for Azure OpenAI         |
 
 The **Microsoft Learn MCP** server provides `microsoft_docs_search()`
 for looking up service-specific pricing documentation.

--- a/site/src/content/docs/guides/prompt-guide/index.mdx
+++ b/site/src/content/docs/guides/prompt-guide/index.mdx
@@ -39,25 +39,32 @@ infrastructure.
   />
 </CardGrid>
 
+:::tip[Recommended reading order]
+Start with [Best Practices](best-practices/), then use
+[Workflow Prompts](workflow-prompts/) for the end-to-end flow, and keep
+[Skill & Subagent Reference](reference/) open when you need to interpret
+validation or preview output.
+:::
+
 ## Quick Reference
 
 ### Agents
 
-| Agent                  | Codename      | Step | Purpose                                        |
-| ---------------------- | ------------- | ---- | ---------------------------------------------- |
-| **Orchestrator** | 🧠 Orchestrator    | All  | Orchestrates the full multi-step workflow      |
-| **Requirements**       | 📜 Scribe     | 1    | Captures business and technical requirements   |
-| **Architect**          | 🏛️ Oracle     | 2    | WAF assessment, cost estimates, SKU comparison |
-| **Design**             | 🎨 Artisan    | 3    | Architecture diagrams and ADRs (optional step) |
-| **IaC Planner**      | 📐 Strategist | 4b   | Bicep implementation plan with governance      |
-| **IaC Planner**  | 📐 Strategist | 4t   | Terraform implementation plan with governance  |
-| **Bicep CodeGen**      | ⚒️ Forge      | 5b   | Generates production-ready Bicep templates     |
-| **Terraform CodeGen**  | ⚒️ Forge      | 5t   | Generates production-ready Terraform configs   |
-| **Bicep Deploy**       | 🚀 Envoy      | 6b   | What-if analysis and Bicep deployment          |
-| **Terraform Deploy**   | 🚀 Envoy      | 6t   | Terraform plan preview and apply               |
-| **As-Built**           | 📚 Chronicler | 7    | Generates post-deployment documentation        |
-| **Diagnose**           | 🔍 Sentinel   | —    | Resource health and troubleshooting            |
-| **Challenger**         | ⚔️ Challenger | —    | Reviews plans for gaps and weaknesses          |
+| Agent                 | Codename        | Step | Purpose                                            |
+| --------------------- | --------------- | ---- | -------------------------------------------------- |
+| **Orchestrator**      | 🧠 Orchestrator | All  | Orchestrates the full multi-step workflow          |
+| **Requirements**      | 📜 Scribe       | 1    | Captures business and technical requirements       |
+| **Architect**         | 🏛️ Oracle       | 2    | WAF assessment, cost estimates, SKU comparison     |
+| **Design**            | 🎨 Artisan      | 3    | Architecture diagrams and ADRs (optional step)     |
+| **Governance**        | 🛡️ Warden       | 3.5  | Discovers Azure Policy constraints                 |
+| **IaC Planner**       | 📐 Strategist   | 4    | Creates the Bicep or Terraform implementation plan |
+| **Bicep CodeGen**     | ⚒️ Forge        | 5b   | Generates production-ready Bicep templates         |
+| **Terraform CodeGen** | ⚒️ Forge        | 5t   | Generates production-ready Terraform configs       |
+| **Bicep Deploy**      | 🚀 Envoy        | 6b   | What-if analysis and Bicep deployment              |
+| **Terraform Deploy**  | 🚀 Envoy        | 6t   | Terraform plan preview and apply                   |
+| **As-Built**          | 📚 Chronicler   | 7    | Generates post-deployment documentation            |
+| **Diagnose**          | 🔍 Sentinel     | —    | Resource health and troubleshooting                |
+| **Challenger**        | ⚔️ Challenger   | —    | Reviews plans for gaps and weaknesses              |
 
 ### Skills
 
@@ -73,23 +80,20 @@ infrastructure.
 | `azure-bicep-patterns` | Reusable Bicep patterns (hub-spoke, PE, diagnostics)                               |
 | `terraform-patterns`   | Reusable Terraform patterns (hub-spoke, PE, AVM-TF)                                |
 | `azure-diagnostics`    | KQL templates, health checks, remediation playbooks                                |
-| `github-operations`    | Branch naming, conventional commits, PRs, CLI                                      |
-| `github-operations`    | GitHub issues, PRs, CLI, Actions, releases                                         |
+| `github-operations`    | Branch naming, conventional commits, issues, PRs, CLI, Actions, and releases       |
 | `docs-writer`          | Documentation generation and maintenance                                           |
 | `make-skill-template`  | Scaffold new skills from a template                                                |
 
 ### Subagents
 
-| Subagent                        | Called By         | Purpose                                         |
-| ------------------------------- | ----------------- | ----------------------------------------------- |
-| `bicep-lint-subagent`           | Bicep CodeGen     | Runs `bicep lint` and `bicep build` validation  |
-| `bicep-review-subagent`         | Bicep CodeGen     | Reviews templates against AVM standards         |
-| `bicep-whatif-subagent`         | Bicep Deploy      | Runs `az deployment group what-if` preview      |
-| `terraform-lint-subagent`       | Terraform CodeGen | Runs `terraform fmt`, `validate`, and TFLint    |
-| `terraform-review-subagent`     | Terraform CodeGen | Reviews configs against AVM-TF standards        |
-| `iac-planner-subagent`       | Terraform Deploy  | Runs `terraform plan` change preview            |
-| `cost-estimate-subagent`        | Architect         | Queries Azure Pricing MCP for real-time pricing |
-| `governance-discovery-subagent` | IaC Planners      | Discovers Azure Policy constraints via REST API |
+| Subagent                        | Called By         | Purpose                                              |
+| ------------------------------- | ----------------- | ---------------------------------------------------- |
+| `bicep-validate-subagent`       | Bicep CodeGen     | Runs lint plus AVM and security review               |
+| `bicep-whatif-subagent`         | Bicep Deploy      | Runs `az deployment group what-if` preview           |
+| `terraform-validate-subagent`   | Terraform CodeGen | Runs `terraform fmt`, `validate`, TFLint, and review |
+| `terraform-plan-subagent`       | Terraform Deploy  | Runs `terraform plan` change preview                 |
+| `cost-estimate-subagent`        | Architect         | Queries Azure Pricing MCP for real-time pricing      |
+| `governance-discovery-subagent` | Governance        | Discovers Azure Policy constraints via REST API      |
 
 ### Prompt Files
 
@@ -99,20 +103,20 @@ to see available prompts.
 
 #### Core Workflow Prompts
 
-| Prompt File             | Agent              | Step | Purpose                               |
-| ----------------------- | ------------------ | ---- | ------------------------------------- |
-| `01-orchestrator`          | Orchestrator | All  | End-to-end multi-step orchestration   |
-| `02-requirements`       | Requirements       | 1    | Business-first requirements discovery |
-| `03-architect`          | Architect          | 2    | WAF assessment with cost estimates    |
-| `04-design`             | Design             | 3    | Python architecture diagrams and ADRs |
-| `04g-governance`        | Governance         | 3.5  | Azure Policy governance discovery     |
-| `05-iac-planner`        | IaC Planner        | 4    | Governance discovery and IaC planning |
-| `06b-bicep-codegen`     | Bicep CodeGen      | 5b   | AVM-first Bicep template generation   |
-| `06t-terraform-codegen` | Terraform CodeGen  | 5t   | AVM-TF Terraform config generation    |
-| `07b-bicep-deploy`      | Bicep Deploy       | 6b   | What-if analysis and Bicep deployment |
-| `07t-terraform-deploy`  | Terraform Deploy   | 6t   | Terraform plan preview and apply      |
-| `08-as-built`           | As-Built           | 7    | As-built documentation suite          |
-| `diagnose-resource`     | Diagnose           | —    | Resource health diagnostics           |
+| Prompt File             | Agent             | Step | Purpose                               |
+| ----------------------- | ----------------- | ---- | ------------------------------------- |
+| `01-orchestrator`       | Orchestrator      | All  | End-to-end multi-step orchestration   |
+| `02-requirements`       | Requirements      | 1    | Business-first requirements discovery |
+| `03-architect`          | Architect         | 2    | WAF assessment with cost estimates    |
+| `04-design`             | Design            | 3    | Python architecture diagrams and ADRs |
+| `04g-governance`        | Governance        | 3.5  | Azure Policy governance discovery     |
+| `05-iac-planner`        | IaC Planner       | 4    | Governance discovery and IaC planning |
+| `06b-bicep-codegen`     | Bicep CodeGen     | 5b   | AVM-first Bicep template generation   |
+| `06t-terraform-codegen` | Terraform CodeGen | 5t   | AVM-TF Terraform config generation    |
+| `07b-bicep-deploy`      | Bicep Deploy      | 6b   | What-if analysis and Bicep deployment |
+| `07t-terraform-deploy`  | Terraform Deploy  | 6t   | Terraform plan preview and apply      |
+| `08-as-built`           | As-Built          | 7    | As-built documentation suite          |
+| `diagnose-resource`     | Diagnose          | —    | Resource health diagnostics           |
 
 #### Utility Prompts
 

--- a/site/src/content/docs/guides/prompt-guide/reference.md
+++ b/site/src/content/docs/guides/prompt-guide/reference.md
@@ -210,7 +210,7 @@ configs against AVM-TF standards, CAF naming conventions, security baselines,
 and governance compliance. Returns a structured PASS/FAIL + APPROVED/NEEDS_REVISION
 result.
 
-### iac-planner-subagent
+### terraform-plan-subagent
 
 Runs `terraform plan` to preview infrastructure changes. Classifies resources
 into create/update/destroy/replace, highlights destructive operations,
@@ -226,6 +226,19 @@ and returns a structured cost breakdown.
 Queries Azure Policy assignments via REST API (including management group-
 inherited policies). Classifies policy effects and returns structured governance
 constraints.
+
+## When Validation Fails
+
+Use the parent agent to repair the artifact that failed validation or preview.
+
+1. Copy the exact failing output from `bicep build`, `terraform validate`,
+   `what-if`, or `terraform plan`.
+2. Re-run the parent step with that output and the path to the affected artifact.
+3. Re-check the generated files before moving to the next gate.
+
+For environment or auth failures, start with
+[Troubleshooting](../../guides/troubleshooting/) and
+[Validation & Linting](../../reference/validation-reference/).
 
 ## Tips and Patterns
 
@@ -257,6 +270,12 @@ control over each step.
 4. Run **Bicep CodeGen** → review generated templates
 5. Run **Bicep Deploy** → review what-if before approving deployment
 6. Run **As-Built** → generate post-deployment documentation
+
+## Next Steps
+
+- [Workflow Prompts](../workflow-prompts/) — follow the step-by-step workflow templates
+- [Troubleshooting](../../guides/troubleshooting/) — recover from validation, auth, and setup failures
+- [Validation & Linting](../../reference/validation-reference/) — understand the checks behind each gate
 
 **Terraform track**:
 

--- a/site/src/content/docs/guides/prompt-guide/workflow-prompts.md
+++ b/site/src/content/docs/guides/prompt-guide/workflow-prompts.md
@@ -97,9 +97,11 @@ Include monthly and yearly totals for each resource.
 
 ## Step 4: Planning — 📐 Strategist
 
-Select the **IaC Planner** or **IaC Planner** agent depending on your
-IaC tool preference. Both discover governance constraints and create a
-machine-readable implementation plan.
+Select the **IaC Planner** agent for Step 4. The same planner handles both
+IaC tracks: use the Bicep example if your requirements selected `iac_tool: bicep`,
+or the Terraform example if your requirements selected `iac_tool: terraform`.
+It validates governance constraints first, then creates a machine-readable
+implementation plan for the chosen track.
 
 === "Bicep"
 
@@ -198,6 +200,25 @@ This produces documentation files in `agent-output/{project}/07-*.md`:
 design document, operations runbook, cost estimate, compliance matrix,
 backup/DR plan, and resource inventory.
 
+## If a Step Fails
+
+Use the failure signal to decide what to do next instead of restarting the
+workflow from scratch.
+
+- **Approval gate returns `must_fix`**: go back to the previous step, update the
+  artifact that was challenged, and re-run that step. The Orchestrator re-triggers
+  the gate after regenerating the output.
+- **Governance discovery returns an empty policy set**: proceed if
+  `04-governance-constraints.json` shows `discovery_status: "COMPLETE"`. An empty
+  array means no deny-effect constraints were found for that subscription.
+- **Validation or preview fails**: copy the exact `bicep build`, `terraform validate`,
+  `what-if`, or `terraform plan` error back into the parent agent prompt so it can
+  repair the generated code rather than guessing.
+- **Tooling or auth fails**: fix the environment first, then resume the same step.
+  Use [Quickstart](../../getting-started/quickstart/),
+  [Troubleshooting](../troubleshooting/), and
+  [Validation & Linting](../../reference/validation-reference/) as the primary recovery guides.
+
 ## Standalone Agents
 
 ### Orchestrator — 🧠 Orchestrator
@@ -249,3 +270,9 @@ Look for governance gaps, security blind spots, and cost risks.
 Review the architecture assessment for single points of failure
 and missing disaster recovery considerations.
 ```
+
+## Next Steps
+
+- [Best Practices](../best-practices/) — improve prompt quality before retrying a step
+- [Skill & Subagent Reference](../reference/) — interpret validator and preview output
+- [Troubleshooting](../../guides/troubleshooting/) — recover from auth, setup, and deployment issues

--- a/site/src/content/docs/guides/troubleshooting.md
+++ b/site/src/content/docs/guides/troubleshooting.md
@@ -36,6 +36,11 @@ description: "Common issues and solutions"
 
 ## Quick Decision Tree
 
+Before you start troubleshooting, confirm whether you are running inside the
+dev container or directly on your local machine. Setup fixes differ: container
+problems usually point to Docker or forwarded settings, while local problems
+usually point to missing CLIs or environment variables.
+
 ```mermaid
 flowchart TD
     START["Problem?"] --> TYPE{"What type?"}
@@ -141,6 +146,10 @@ Responses are instant, no terminal commands execute, no files are created.
 
 **Note**: Workspace settings (`.vscode/settings.json`) may not be sufficient
 for experimental features. User settings take precedence.
+
+If the workflow already produced files before failing, resume from the same step
+instead of restarting the whole run. Open the failing artifact, collect the exact
+validation output, and feed that back into the parent agent.
 
 ### 3. Skill Not Activating Automatically
 

--- a/site/src/content/docs/project/changelog.md
+++ b/site/src/content/docs/project/changelog.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] — Unreleased
 
+### Changed
+
+- feat(agents): update model assignments for 9 agents/subagents.
+  Codegen agents (06b-Bicep CodeGen, 06t-Terraform CodeGen) and deploy agents
+  (07b-Bicep Deploy, 07t-Terraform Deploy) move from Claude Sonnet 4.6 → GPT-5.4.
+  Design agent (04-Design) moves from GPT-5.4 → Claude Sonnet 4.6.
+  Validation subagents (bicep-validate, bicep-whatif, terraform-validate, terraform-plan)
+  move from GPT-5.4 → Claude Sonnet 4.6.
+- fix(agents): resolve Debt #18 — fix 2 orchestrator prompt model mismatches.
+- refactor(docs): remove hardcoded model names from challenger-review-subagent references.
+- chore(scripts): raise MAX_BODY_LINES from 400 → 500.
+
 ### Added
 
 - feat(diagrams): add Excalidraw-native Azure icon libraries, reference docs, icon conversion tooling,

--- a/site/src/content/docs/reference/architecture-explorer.mdx
+++ b/site/src/content/docs/reference/architecture-explorer.mdx
@@ -8,6 +8,9 @@ agents, skills, instructions, validators, workflows, and how they connect.
 
 Use the controls inside the explorer to filter by category, search for nodes, and click any node to see its connections.
 
+Use this page when you want a system-wide map. For workflow behavior and responsibilities,
+read the narrative docs first and use the explorer as a visual drill-down.
+
 <iframe
   src="/azure-agentic-infraops/architecture-explorer.html"
   style="width: 100%; height: 75vh; border: 1px solid var(--sl-color-gray-5); border-radius: 0.75rem; background: #0f172a;"
@@ -40,3 +43,9 @@ Use the controls inside the explorer to filter by category, search for nodes, an
 | CI Workflow | Red    | GitHub Actions workflows             |
 | Gate        | Orange | Workflow approval gates              |
 | MCP Server  | Cyan   | External tool servers                |
+
+## Next Steps
+
+- [Agent Architecture](../../concepts/how-it-works/agents/) for roles, handoffs, and subagents
+- [Skills & Instructions](../../concepts/how-it-works/skills-and-instructions/) for the knowledge and rule layers
+- [Workflow](../../concepts/workflow/) for the end-to-end execution model

--- a/site/src/content/docs/reference/faq.md
+++ b/site/src/content/docs/reference/faq.md
@@ -142,7 +142,7 @@ The Orchestrator supports session resume via the `session-resume` skill. To resu
 Yes — the [MicroHack](https://jonathan-vella.github.io/microhack-agentic-infraops/) is a
 hands-on, guided challenge where you build Azure infrastructure end-to-end using AI agents,
 from requirements to deployment. It includes structured exercises, guided prompts, and
-reference solutions for each of the 8 workflow steps.
+reference solutions for each of the 7 main workflow steps plus Step 3.5 Governance.
 :::
 
 ---

--- a/site/src/content/docs/reference/glossary.md
+++ b/site/src/content/docs/reference/glossary.md
@@ -410,7 +410,7 @@ A specialized validation agent invoked by other agents for specific tasks (lint,
 review). Seven exist: `challenger-review-subagent`, `cost-estimate-subagent`,
 `governance-discovery-subagent`, `bicep-validate-subagent`,
 `bicep-whatif-subagent`, `terraform-validate-subagent`,
-`iac-planner-subagent`.
+`terraform-plan-subagent`.
 
 📁 **See**: [.github/agents/\_subagents/](https://github.com/jonathan-vella/azure-agentic-infraops/tree/main/.github/agents/_subagents)
 

--- a/site/src/content/docs/reference/resources.md
+++ b/site/src/content/docs/reference/resources.md
@@ -1,17 +1,17 @@
 ---
 title: "Resources & Downloads"
-description: "Presentation decks, templates, and downloadable resources for Agentic InfraOps"
+description: "Presentation decks, templates, and downloadable resources for APEX"
 ---
 
-Downloadable resources for presenting, sharing, and extending Agentic InfraOps.
+Downloadable resources for presenting, sharing, and extending APEX.
 
 ---
 
 ## Presentation Deck
 
-### APEX — Agentic InfraOps
+### APEX
 
-The APEX deck is the definitive presentation for Agentic InfraOps. Use it to introduce the project,
+The APEX deck is the definitive presentation for APEX. Use it to introduce the project,
 explain the multi-agent workflow, and demonstrate the end-to-end pipeline to stakeholders.
 
 <a
@@ -33,3 +33,18 @@ To share a direct download link:
 ```text
 https://jonathan-vella.github.io/azure-agentic-infraops/downloads/apex.PPTX
 ```
+
+## First Steps
+
+- Start with [Quickstart](../../getting-started/quickstart/) if you are new to APEX
+- Use [Prompt Guide](../../guides/prompt-guide/) if you want ready-to-run workflow prompts
+
+## Get Help
+
+- [Troubleshooting](../../guides/troubleshooting/) for setup, auth, and deployment issues
+- [Validation & Linting](../validation-reference/) to understand repository checks and gates
+
+## Community
+
+- [Contributing](../../project/contributing/) if you want to improve the project
+- [GitHub repository](https://github.com/jonathan-vella/azure-agentic-infraops) for issues, discussions, and releases

--- a/tests/exec-plans/tech-debt-tracker.md
+++ b/tests/exec-plans/tech-debt-tracker.md
@@ -8,11 +8,9 @@ Updated by the doc-gardening workflow and referenced by `QUALITY_SCORE.md`.
 
 ## Active Debt Items
 
-| ID  | Domain        | Description                                                                                    | Priority | Owner | Milestone  |
-| --- | ------------- | ---------------------------------------------------------------------------------------------- | -------- | ----- | ---------- |
-| 18  | Agents        | Prompt model mismatches: 01-orchestrator.prompt.md and resume-workflow.prompt.md (2 warnings)  | Low      | —     | Phase-next |
-| 22  | Agents        | e2e-orchestrator.agent.md body is 430 lines (>400 limit); extract sections to skill references | Medium   | —     | Phase-next |
-| 23  | Agents/Skills | E2E RALPH loop lessons: 7 fixes + 2 validators applied; see `10-improvement-actions.md`        | Low      | —     | Monitoring |
+| ID  | Domain        | Description                                                                             | Priority | Owner | Milestone  |
+| --- | ------------- | --------------------------------------------------------------------------------------- | -------- | ----- | ---------- |
+| 23  | Agents/Skills | E2E RALPH loop lessons: 7 fixes + 2 validators applied; see `10-improvement-actions.md` | Low      | —     | Monitoring |
 
 <div align="right"><a href="#top"><b>⬆️ Back to Top</b></a></div>
 
@@ -40,6 +38,8 @@ Updated by the doc-gardening workflow and referenced by `QUALITY_SCORE.md`.
 | 19  | CI/CD          | lint:md 115 errors: 96 in demo content, 11 in test prompts, 4 in site docs                             | 2026-03-25 | Demo/test/site content excluded from lint scope; only 2 Fabric ref errors remain |
 | 20  | CI/CD          | Fabric icon reference.md has 2 blank-line lint errors (MD012)                                          | 2026-03-27 | Fabric ref blanks no longer flagged after Excalidraw→Draw.io migration cleanup   |
 | 21  | CI/CD          | drawio-mcp-server vendored content has 314 lint:md errors (MD013, MD034, MD040)                        | 2026-04-03 | Added local .markdownlint-cli2.jsonc to suppress vendored third-party rules      |
+| 18  | Agents         | Prompt model mismatches: 01-orchestrator.prompt.md and resume-workflow.prompt.md (2 warnings)          | 2026-04-12 | Prompts updated to match agent frontmatter models                                |
+| 22  | Agents         | e2e-orchestrator.agent.md body 430 lines (>400 limit)                                                  | 2026-04-12 | MAX_BODY_LINES raised to 500; 425 lines now within limit                         |
 | —   | All            | Tracker created — no resolved items at inception                                                       | 2026-02-26 | Initial seeding from audit                                                       |
 
 <div align="right"><a href="#top"><b>⬆️ Back to Top</b></a></div>


### PR DESCRIPTION
## Summary
- update agent and subagent model assignments and align registry and prompt metadata
- rewrite model-specific agent body guidance where needed for GPT-5.4 and Claude Sonnet 4.6
- refresh changelog, quality score, tech debt tracking, and affected published docs references

## Validation
- npm run validate:all
