### PR TITLE
chore: ignore pnpm store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ build/
 
 # Node (if any demos use it)
 node_modules/
+.pnpm-store/
 
 # Python (if any scripts)
 __pycache__/


### PR DESCRIPTION
## Summary
Add `.pnpm-store/` to `.gitignore` so local pnpm cache data does not appear in the working tree.

## Testing
- Pre-commit hooks
- Pre-push diff-based checks