### PR TITLE
fix(agents): optimize governance discovery to reduce context window waste

### DIFF
--- a/.github/agents/04g-governance.agent.md
+++ b/.github/agents/04g-governance.agent.md
@@ -59,6 +59,11 @@ Before doing any work, read:
 1. Read `.github/skills/azure-defaults/SKILL.digest.md` — Governance Discovery section, regions, tags
 2. Read `.github/skills/azure-artifacts/SKILL.digest.md` — H2 template for `04-governance-constraints.md`
 3. Read the template: `.github/skills/azure-artifacts/templates/04-governance-constraints.template.md`
+4. Read `.github/instructions/references/iac-policy-compliance.md` — **MANDATORY before writing JSON**.
+   This defines the downstream JSON contract (`discovery_status`, `policies` array,
+   dot-separated `azurePropertyPath`, `bicepPropertyPath` formats) that Step 4/5 agents
+   and review subagents consume. Loading this reference before Phase 2 prevents iterative
+   contract-mismatch rework.
 
 ## Prerequisites
 
@@ -103,6 +108,16 @@ If discovery fails, STOP. Do not proceed with incomplete policy data.
    group-inherited), classifies effects. Pass the user's scope choice to constrain the query.
 2. **Review result** — Status must be COMPLETE (if PARTIAL or FAILED, STOP and present error)
 
+### Phase 1.5: Subagent Fallback
+
+If the `governance-discovery-subagent` invocation fails (network error, timeout,
+or GOAWAY), fall back to direct Azure REST discovery in the main agent context.
+**When using the fallback path**, include the full JSON schema from
+`.github/agents/_subagents/governance-discovery-subagent.agent.md` §"JSON Constraint Schema"
+and `.github/instructions/references/iac-policy-compliance.md` in a single
+structured prompt so the contract is satisfied on the first write — do not
+discover the schema iteratively through challenger feedback.
+
 ### Phase 2: Generate Artifacts
 
 1. Populate `04-governance-constraints.md` matching H2 template from azure-artifacts skill
@@ -110,15 +125,26 @@ If discovery fails, STOP. Do not proceed with incomplete policy data.
      cross-navigation table, attribution, Mermaid diagram (tag inheritance flowchart), and
      traffic-light indicators (✅ / ⚠️ / ❌ — all three must appear in status columns)
 2. Populate `04-governance-constraints.json` with machine-readable policy data
+   - Root object MUST include `discovery_status` field (value `"COMPLETE"`, `"PARTIAL"`, or `"FAILED"`)
+     and a `policies` array — this is the envelope that Step 4 and E2E agents validate at startup
    - Every Deny/Modify policy MUST include both `bicepPropertyPath` and `azurePropertyPath`
+     using dot-separated format (e.g., `storageAccount.properties.minimumTlsVersion`)
+   - For tag-enforcement policies (Deny/Modify that target tags, not resource properties),
+     set `bicepPropertyPath` and `azurePropertyPath` to `"resourceGroups::tags"` / `"resourceGroup.tags"`
+     and include a separate `requiredTags` array — do NOT leave these fields null
    - Normalize tag names — verify exact tag key names from live policy (no drift)
-3. Run `npm run lint:artifact-templates` and fix any errors
+   - Include `assignment_inventory` array with all discovered assignments for audit trail
+3. **Self-validate before challenger**: run `npm run lint:artifact-templates`, verify
+   JSON parses with `python3 -m json.tool`, and confirm the JSON has `discovery_status`
+   and `policies` keys. Fix any issues **before** invoking the challenger.
 
 **Policy Effect Reference**: `azure-defaults/references/policy-effect-decision-tree.md`
 
-### Phase 2.5: Challenger Review
+### Phase 2.5: Challenger Review (max 2 passes)
 
 Run a single comprehensive adversarial review on the governance artifacts.
+**Cap**: Maximum 2 challenger passes total. If must-fix findings remain after
+pass 2, present them to the user at the approval gate rather than looping further.
 
 1. Delegate to `challenger-review-subagent` using the `agent` tool via `#tool:agent`:
    - `artifact_path` = `agent-output/{project}/04-governance-constraints.md`
@@ -128,8 +154,11 @@ Run a single comprehensive adversarial review on the governance artifacts.
    - `pass_number` = `1`
    - `prior_findings` = `null`
 2. Write returned JSON to `agent-output/{project}/challenge-findings-governance-constraints-pass1.json`
-3. If any `must_fix` findings: fix the governance artifacts and re-run Phase 2.5
-4. Include challenger findings summary in the Gate 2.5 presentation below
+3. If any `must_fix` findings: batch-fix ALL findings in one edit pass, then re-run
+   the challenger exactly once more (pass 2). Do NOT fix-then-review one finding at a time.
+4. If must-fix findings remain after pass 2: document them at the approval gate
+   and let the user decide whether to accept, override, or request further iteration.
+5. Include challenger findings summary in the Gate 2.5 presentation below
 
 ### Phase 3: Approval Gate
 

--- a/.github/agents/_subagents/governance-discovery-subagent.agent.md
+++ b/.github/agents/_subagents/governance-discovery-subagent.agent.md
@@ -202,26 +202,37 @@ Recommendation: {proceed|adapt plan|escalate}
 
 ## JSON Constraint Schema (04-governance-constraints.json)
 
-For every Deny/Modify policy that affects specific resource properties, include
-BOTH `bicepPropertyPath` AND `azurePropertyPath` in the JSON output:
+The JSON file MUST use an envelope object (NOT a bare array) with these top-level fields:
 
 ```json
 {
+  "discovery_status": "COMPLETE",
+  "project": "{project-name}",
+  "subscription": { "displayName": "...", "subscriptionId": "...", "tenantId": "..." },
+  "discovery_timestamp": "2026-01-01T00:00:00Z",
+  "discovery_summary": { "assignment_total": 0, "subscription_scope_count": 0, "management_group_inherited_count": 0 },
+  "assignment_inventory": [ { "displayName": "...", "scope": "...", "assignmentType": "subscription" } ],
   "policies": [
     {
-      "name": "Require TLS 1.2 for Storage",
+      "displayName": "Require TLS 1.2 for Storage",
+      "policyDefinitionId": "/providers/...",
       "effect": "Deny",
-      "scope": "Management Group",
+      "scope": "/providers/Microsoft.Management/managementGroups/...",
+      "classification": "blocker",
+      "affectedResourceTypes": ["Microsoft.Storage/storageAccounts"],
       "bicepPropertyPath": "storageAccounts::properties.minimumTlsVersion",
       "azurePropertyPath": "storageAccount.properties.minimumTlsVersion",
       "requiredValue": "TLS1_2",
-      "status": "compliant"
+      "appliesToArchitecture": true
     }
   ]
 }
 ```
 
-Field definitions:
+**Mandatory top-level fields**: `discovery_status` (COMPLETE/PARTIAL/FAILED) and `policies`
+array. Step 4 (IaC Planner) and E2E orchestrator validate these at startup and STOP if missing.
+
+**Field definitions**:
 
 - **`bicepPropertyPath`**: Bicep resource type (lowerCamelCase) `::` ARM property path.
   Format: `{bicepResourceType}::{arm.property.path}`
@@ -234,9 +245,13 @@ Field definitions:
 
 - **`requiredValue`**: The exact value required by the Deny policy.
 
-Both fields MUST be populated for every Deny/Modify policy. If a policy does not
-target a specific resource property (e.g., tag enforcement, location restriction),
-omit both fields.
+Both fields MUST be populated for every Deny/Modify policy. For tag-enforcement
+policies that target tags rather than resource properties, use:
+
+- `bicepPropertyPath`: `"resourceGroups::tags"`
+- `azurePropertyPath`: `"resourceGroup.tags"`
+- Add a `requiredTags` array with the exact tag key names
+- Add `"pathSemantics": "tag-policy-non-property"` to signal downstream consumers
 
 ## Resource-Specific Filtering
 

--- a/.github/instructions/references/governance-discovery-reference.md
+++ b/.github/instructions/references/governance-discovery-reference.md
@@ -105,13 +105,20 @@ Discovered from Azure Policy assignment "JV-Inherit Multiple Tags" (effect: modi
 
 ### JSON Schema (`04-governance-constraints.json`)
 
-- Root: array of policy objects
-- Required fields: `displayName`, `policyDefinitionId`, `effect`, `scope`
+- Root: envelope object with `discovery_status` and `policies` fields (NOT a bare array)
+- **`discovery_status`**: `"COMPLETE"`, `"PARTIAL"`, or `"FAILED"` — validated by Step 4 at startup
+- **`policies`**: array of policy objects
+- Required fields per policy: `displayName`, `policyDefinitionId`, `effect`, `scope`
 - For `Deny` policies, add machine-actionable fields:
-  - `bicepPropertyPath` (e.g., `"properties.publicNetworkAccess"`)
+  - `bicepPropertyPath` (e.g., `"storageAccounts::properties.publicNetworkAccess"`)
   - `azurePropertyPath` (e.g., `"storageAccount.properties.publicNetworkAccess"`)
   - `requiredValue` (e.g., `"Disabled"`)
   - `affectedResourceTypes` (e.g., `["Microsoft.Storage/storageAccounts"]`)
+- For tag-enforcement policies (Deny/Modify targeting tags, not resource properties):
+  - `bicepPropertyPath`: `"resourceGroups::tags"`
+  - `azurePropertyPath`: `"resourceGroup.tags"`
+  - `requiredTags`: array of exact tag key names
+  - `pathSemantics`: `"tag-policy-non-property"`
 - These fields enable programmatic compliance verification by Code Generators
   and review subagents across both Bicep and Terraform
 


### PR DESCRIPTION
## Problem

Context optimization analysis (debug-log-derived, session 2026-04-14) found the
governance discovery prompt consumed **18 minutes / 66 model calls** due to 4
structural inefficiencies in the agent workflow.

### Time Budget (from debug logs)

| Category | Time | % |
|----------|------|---|
| Main agent turns (27 calls) | 8.4 min | 48% |
| Challenger review (19 calls, 5 invocations) | 7.9 min | 45% |
| Helper calls (gpt-4o-mini, 20 calls) | 1.2 min | 7% |
| **Total model time** | **17.5 min** | |

## Root Causes & Fixes

### 1. Read downstream JSON contract before writing (~3 min saved)
The governance JSON was rewritten 3 times because the correct downstream contract
(`discovery_status` envelope, dot-separated `azurePropertyPath`) wasn't loaded
before the first write. Each rewrite triggered a new challenger review cycle.

**Fix**: Agent now reads `iac-policy-compliance.md` as a mandatory prerequisite in
the Read Skills First section, before Phase 2 artifact generation.

### 2. Batch all challenger fixes in one pass (~5 min saved)
The old Phase 2.5 said "fix and re-run" with no batching instruction, causing a
fix-one-finding → re-review → fix-next-finding → re-review loop.

**Fix**: Phase 2.5 now explicitly requires batch-fixing ALL must-fix findings in one
edit pass before re-running the challenger.

### 3. Cap challenger invocations to max 2 passes (~2 min saved)
No upper bound existed on challenger re-runs, allowing 5 invocations when each pass
found a new contract-mismatch issue.

**Fix**: Phase 2.5 now caps at 2 challenger passes. Remaining must-fix findings after
pass 2 are surfaced at the approval gate for user decision.

### 4. Pre-build subagent fallback with full spec (~1 min saved)
When the `governance-discovery-subagent` failed (network GOAWAY), the main agent
discovered the JSON schema iteratively through challenger feedback instead of
including it in the fallback prompt.

**Fix**: New Phase 1.5 documents the fallback path and requires the full JSON schema
from the subagent definition and `iac-policy-compliance.md` to be included in a
single structured prompt when using the fallback.

### Supporting: JSON schema alignment
- Subagent JSON schema now documents the `discovery_status` envelope requirement
- Tag-enforcement policies get explicit `pathSemantics` and non-null path fields
- Self-validation step added before challenger invocation

## Expected Impact
Governance discovery should complete in **5–7 minutes** (was ~18 minutes).

## Files Changed
- `.github/agents/04g-governance.agent.md` — core workflow changes
- `.github/agents/_subagents/governance-discovery-subagent.agent.md` — JSON schema
- `.github/instructions/references/governance-discovery-reference.md` — JSON schema

## Validation
- `npm run lint:agent-frontmatter` ✅
- `npm run lint:md` ✅ (0 errors)
- Patch applies cleanly to upstream main