### PR TITLE
feat(agents): model realignment v2 — Opus 4.6, Sonnet 4.6, GPT-5.4

### DIFF
--- a/.github/agent-registry.json
+++ b/.github/agent-registry.json
@@ -5,7 +5,7 @@
   "agents": {
     "orchestrator": {
       "agent": ".github/agents/01-orchestrator.agent.md",
-      "model": "GPT-5.4",
+      "model": "Claude Opus 4.6",
       "skills": [
         "golden-principles",
         "session-resume",
@@ -95,7 +95,7 @@
     "iac-code": {
       "bicep": {
         "agent": ".github/agents/06b-bicep-codegen.agent.md",
-        "model": "GPT-5.4",
+        "model": "Claude Sonnet 4.6",
         "skills": [
           "azure-defaults",
           "azure-artifacts",
@@ -108,7 +108,7 @@
       },
       "terraform": {
         "agent": ".github/agents/06t-terraform-codegen.agent.md",
-        "model": "GPT-5.4",
+        "model": "Claude Sonnet 4.6",
         "skills": [
           "azure-defaults",
           "azure-artifacts",
@@ -199,7 +199,7 @@
     },
     "e2e-orchestrator": {
       "agent": ".github/agents/e2e-orchestrator.agent.md",
-      "model": "GPT-5.4",
+      "model": "Claude Opus 4.6",
       "skills": [
         "session-resume",
         "workflow-engine",
@@ -231,25 +231,25 @@
     },
     "bicep-validate-subagent": {
       "agent": ".github/agents/_subagents/bicep-validate-subagent.agent.md",
-      "model": "Claude Sonnet 4.6",
+      "model": "GPT-5.4",
       "skills": ["azure-bicep-patterns"],
       "invokable": false
     },
     "bicep-whatif-subagent": {
       "agent": ".github/agents/_subagents/bicep-whatif-subagent.agent.md",
-      "model": "Claude Sonnet 4.6",
+      "model": "GPT-5.4",
       "skills": [],
       "invokable": false
     },
     "terraform-validate-subagent": {
       "agent": ".github/agents/_subagents/terraform-validate-subagent.agent.md",
-      "model": "Claude Sonnet 4.6",
+      "model": "GPT-5.4",
       "skills": ["terraform-patterns", "terraform-test"],
       "invokable": false
     },
     "terraform-plan-subagent": {
       "agent": ".github/agents/_subagents/terraform-plan-subagent.agent.md",
-      "model": "Claude Sonnet 4.6",
+      "model": "GPT-5.4",
       "skills": [],
       "invokable": false
     }

--- a/.github/agents/01-orchestrator.agent.md
+++ b/.github/agents/01-orchestrator.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 01-Orchestrator
 description: Master orchestrator for the multi-step Azure platform engineering workflow. Coordinates specialized agents (Requirements, Architect, Design, IaC Plan, IaC Code, Deploy) through the complete development cycle with mandatory human approval gates. Routes to Bicep or Terraform agents based on the iac_tool field in 01-requirements.md. Maintains context efficiency by delegating to subagents and preserves human-in-the-loop control at critical decision points.
-model: ["GPT-5.4"]
+model: ["Claude Opus 4.6"]
 argument-hint: Describe the Azure platform engineering project you want to build end-to-end
 user-invocable: true
 agents:
@@ -105,6 +105,16 @@ handoffs:
 # Orchestrator Agent
 
 <!-- Recommended reasoning_effort: high -->
+
+<context_awareness>
+Large agent definition (~850 lines). Monitor context usage. At >60% load SKILL.digest.md;
+at >80% switch to SKILL.minimal.md. Write 00-handoff.md at gates to preserve state.
+</context_awareness>
+
+<subagent_budget>
+Invoke no more than 3 subagents sequentially before checkpointing with the user.
+If a step requires more calls, checkpoint after the third and confirm before continuing.
+</subagent_budget>
 
 Master orchestrator for the multi-step Azure platform engineering workflow.
 

--- a/.github/agents/06b-bicep-codegen.agent.md
+++ b/.github/agents/06b-bicep-codegen.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 06b-Bicep CodeGen
 description: Expert Azure Bicep Infrastructure as Code specialist that creates near-production-ready Bicep templates following best practices and Azure Verified Modules standards. Validates, tests, and ensures code quality.
-model: ["GPT-5.4"]
+model: ["Claude Sonnet 4.6"]
 user-invocable: true
 agents: ["bicep-validate-subagent", "challenger-review-subagent"]
 tools:
@@ -53,6 +53,30 @@ handoffs:
 ---
 
 # Bicep Code Agent
+
+<!-- Recommended reasoning_effort: medium -->
+
+<investigate_before_answering>
+Read the implementation plan and governance constraints before generating any Bicep code.
+Verify AVM module availability and parameter schemas via preflight checks.
+</investigate_before_answering>
+
+<context_awareness>
+Large agent definition (~590 lines). At >60% context, load SKILL.digest.md variants.
+At >80% switch to SKILL.minimal.md and stop re-reading predecessor artifacts.
+</context_awareness>
+
+<scope_fencing>
+Generate Bicep templates and validation artifacts only.
+Do not deploy — that is the Deploy agent's responsibility.
+Do not modify architecture decisions — hand back to Planner.
+</scope_fencing>
+
+<output_contract>
+Phase 1: agent-output/{project}/04-preflight-check.md
+Phase 2-4: infra/bicep/{project}/ templates
+Phase 5: agent-output/{project}/05-implementation-reference.md
+</output_contract>
 
 ## Investigate Before Answering
 
@@ -219,11 +243,11 @@ Build templates in dependency order from `04-implementation-plan.md`.
 If **phased**: add `@allowed` `phase` parameter, wrap modules in `if phase == 'all' || phase == '{name}'`.
 If **single**: no phase parameter needed.
 
-| Round | Content                                                                             |
-| ----- | ----------------------------------------------------------------------------------- |
-| 1     | `main.bicep` (params, vars, `uniqueSuffix`), `main.bicepparam`                      |
-| 2     | Networking, Key Vault, Log Analytics + App Insights                                 |
-| 3     | Compute, Data, Messaging                                                            |
+| Round | Content                                                                                          |
+| ----- | ------------------------------------------------------------------------------------------------ |
+| 1     | `main.bicep` (params, vars, `uniqueSuffix`), `main.bicepparam`                                   |
+| 2     | Networking, Key Vault, Log Analytics + App Insights                                              |
+| 3     | Compute, Data, Messaging                                                                         |
 | 4     | Budget + alerts, Diagnostic settings, role assignments, `azure.yaml` + `deploy.ps1` (deprecated) |
 
 After each round: `bicep build` to catch errors early.

--- a/.github/agents/06t-terraform-codegen.agent.md
+++ b/.github/agents/06t-terraform-codegen.agent.md
@@ -260,7 +260,7 @@ Generate `bootstrap-backend.sh` + `bootstrap-backend.ps1`. Read
 Generate `infra/terraform/{project}/azure.yaml` (azd manifest — **primary deployment method**) with:
 
 ```yaml
-name: { project }
+name: {project}
 infra:
   provider: terraform
   path: .

--- a/.github/agents/06t-terraform-codegen.agent.md
+++ b/.github/agents/06t-terraform-codegen.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 06t-Terraform CodeGen
 description: Expert Azure Terraform Infrastructure as Code specialist that creates near-production-ready Terraform configurations following best practices and Azure Verified Modules (AVM-TF) standards. Validates, tests, and ensures code quality.
-model: ["GPT-5.4"]
+model: ["Claude Sonnet 4.6"]
 user-invocable: true
 agents: ["terraform-validate-subagent", "challenger-review-subagent"]
 tools:
@@ -56,6 +56,30 @@ handoffs:
 ---
 
 # Terraform Code Agent
+
+<!-- Recommended reasoning_effort: medium -->
+
+<investigate_before_answering>
+Read the implementation plan and governance constraints before generating any Terraform code.
+Verify AVM-TF module availability and variable schemas via preflight checks.
+</investigate_before_answering>
+
+<context_awareness>
+Large agent definition (~590 lines). At >60% context, load SKILL.digest.md variants.
+At >80% switch to SKILL.minimal.md and stop re-reading predecessor artifacts.
+</context_awareness>
+
+<scope_fencing>
+Generate Terraform configurations and validation artifacts only.
+Do not deploy — that is the Deploy agent's responsibility.
+Do not modify architecture decisions — hand back to Planner.
+</scope_fencing>
+
+<output_contract>
+Phase 1: agent-output/{project}/04-preflight-check.md
+Phase 2-4: infra/terraform/{project}/ configurations
+Phase 5: agent-output/{project}/05-implementation-reference.md
+</output_contract>
 
 ## Investigate Before Answering
 
@@ -236,7 +260,7 @@ Generate `bootstrap-backend.sh` + `bootstrap-backend.ps1`. Read
 Generate `infra/terraform/{project}/azure.yaml` (azd manifest — **primary deployment method**) with:
 
 ```yaml
-name: {project}
+name: { project }
 infra:
   provider: terraform
   path: .

--- a/.github/agents/_subagents/bicep-validate-subagent.agent.md
+++ b/.github/agents/_subagents/bicep-validate-subagent.agent.md
@@ -1,7 +1,7 @@
 ---
 name: bicep-validate-subagent
 description: "Bicep validation subagent. Runs lint (bicep lint + build) first, then code review (AVM standards, naming, security baseline, governance compliance). Returns structured PASS/FAIL with diagnostics and APPROVED/NEEDS_REVISION/FAILED verdict."
-model: ["Claude Sonnet 4.6"]
+model: ["GPT-5.4"]
 user-invocable: false
 disable-model-invocation: false
 agents: []

--- a/.github/agents/_subagents/bicep-whatif-subagent.agent.md
+++ b/.github/agents/_subagents/bicep-whatif-subagent.agent.md
@@ -1,7 +1,7 @@
 ---
 name: bicep-whatif-subagent
 description: Bicep deployment preview subagent. Runs az deployment group what-if to preview changes before deployment. Analyzes policy violations, resource changes, and cost impact. Returns structured summary for parent agent review.
-model: ["Claude Sonnet 4.6"]
+model: ["GPT-5.4"]
 user-invocable: false
 disable-model-invocation: false
 agents: []

--- a/.github/agents/_subagents/terraform-plan-subagent.agent.md
+++ b/.github/agents/_subagents/terraform-plan-subagent.agent.md
@@ -1,7 +1,7 @@
 ---
 name: terraform-plan-subagent
 description: Terraform deployment preview subagent. Runs terraform plan to preview infrastructure changes before deployment. Classifies resources into create/update/destroy/replace, highlights destructive operations requiring explicit approval, and returns a structured change summary.
-model: ["Claude Sonnet 4.6"]
+model: ["GPT-5.4"]
 user-invocable: false
 disable-model-invocation: false
 agents: []

--- a/.github/agents/_subagents/terraform-validate-subagent.agent.md
+++ b/.github/agents/_subagents/terraform-validate-subagent.agent.md
@@ -1,7 +1,7 @@
 ---
 name: terraform-validate-subagent
 description: "Terraform validation subagent. Runs lint (fmt -check, validate, tfsec) first, then code review (AVM-TF standards, naming, security baseline, RBAC, governance compliance). Returns structured PASS/FAIL with diagnostics and APPROVED/NEEDS_REVISION/FAILED verdict."
-model: ["Claude Sonnet 4.6"]
+model: ["GPT-5.4"]
 user-invocable: false
 disable-model-invocation: false
 agents: []

--- a/.github/instructions/agent-authoring.instructions.md
+++ b/.github/instructions/agent-authoring.instructions.md
@@ -103,35 +103,37 @@ tools: [read/readFile, edit/createFile, agent, "azure-mcp/*"]
 
 Agents that specify `Claude Opus 4.6` as priority model do so deliberately:
 
-- **Opus-first agents** (requirements, architect, iac-plan, diagnose,
-  context-optimizer) require deeper reasoning for architecture decisions,
+- **Opus-first agents** (orchestrator, requirements, architect, iac-plan, diagnose,
+  context-optimizer) require deeper reasoning for orchestration, architecture decisions,
   WAF assessments, planning accuracy, and complex analysis
-- **GPT-5.4 workflow and execution agents** (orchestrator, governance,
-  as-built, challenger wrapper, e2e-orchestrator, codegen, deploy) prioritize
-  strong general reasoning for orchestration, diagrams, governance synthesis,
-  documentation generation, code generation, deployment execution, and structured reviews
-- **Claude Sonnet 4.6 agents** (orchestrator fast path, design, and validation/preview subagents) balance
-  speed with strong execution quality for implementation
-- **GPT-5.3-Codex subagents** handle narrow, high-throughput validation or preview tasks
+- **Claude Sonnet 4.6 agents** (orchestrator fast path, design, bicep codegen,
+  terraform codegen) balance speed with strong execution quality for implementation
+  and code generation
+- **GPT-5.4 workflow and execution agents** (governance, as-built, challenger wrapper,
+  e2e-orchestrator, deploy, and bicep/terraform validation/preview subagents) prioritize
+  strong general reasoning for governance synthesis, documentation generation,
+  deployment execution, structured reviews, and isolated validation
+- **GPT-5.3-Codex subagents** handle narrow, high-throughput tasks (cost estimation)
 
 Current model assignments:
 
-| Agent / Group            | Model                             | Rationale                 |
-| ------------------------ | --------------------------------- | ------------------------- |
-| Orchestrator             | GPT-5.4                           | Orchestration             |
-| Orchestrator (Fast Path) | Claude Sonnet 4.6                 | Streamlined orchestration |
-| Requirements             | Claude Opus 4.6                   | Deep understanding        |
-| Architect                | Claude Opus 4.6                   | WAF analysis + cost       |
-| Design                   | Claude Sonnet 4.6                 | Diagram generation        |
-| Governance               | GPT-5.4                           | Governance discovery      |
-| IaC Planner (unified)    | Claude Opus 4.6                   | Planning accuracy         |
-| Bicep / Terraform Code   | GPT-5.4                           | Code generation           |
-| Deploy                   | GPT-5.4                           | Deployment execution      |
-| As-Built                 | GPT-5.4                           | Documentation generation  |
-| Diagnose                 | Claude Opus 4.6                   | Complex troubleshooting   |
-| Context Optimizer        | Claude Opus 4.6                   | Deep analysis             |
-| Challenger wrapper       | GPT-5.4                           | Review orchestration      |
-| Subagents                | Claude Sonnet 4.6 / GPT-5.3-Codex | Isolated validation       |
+| Agent / Group            | Model             | Rationale                 |
+| ------------------------ | ----------------- | ------------------------- |
+| Orchestrator             | Claude Opus 4.6   | Deep orchestration        |
+| Orchestrator (Fast Path) | Claude Sonnet 4.6 | Streamlined orchestration |
+| Requirements             | Claude Opus 4.6   | Deep understanding        |
+| Architect                | Claude Opus 4.6   | WAF analysis + cost       |
+| Design                   | Claude Sonnet 4.6 | Diagram generation        |
+| Governance               | GPT-5.4           | Governance discovery      |
+| IaC Planner (unified)    | Claude Opus 4.6   | Planning accuracy         |
+| Bicep / Terraform Code   | Claude Sonnet 4.6 | Code generation           |
+| Deploy                   | GPT-5.4           | Deployment execution      |
+| As-Built                 | GPT-5.4           | Documentation generation  |
+| Diagnose                 | Claude Opus 4.6   | Complex troubleshooting   |
+| Context Optimizer        | Claude Opus 4.6   | Deep analysis             |
+| Challenger wrapper       | GPT-5.4           | Review orchestration      |
+| Bicep/TF subagents       | GPT-5.4           | Isolated validation       |
+| Cost estimate subagent   | GPT-5.3-Codex     | High-throughput pricing   |
 
 **Rules:**
 

--- a/.github/prompts/01-orchestrator.prompt.md
+++ b/.github/prompts/01-orchestrator.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: "Kick off a new Azure platform engineering project through the full multi-step workflow with the Orchestrator agent."
 agent: "01-Orchestrator"
-model: "GPT-5.4"
+model: "Claude Opus 4.6"
 argument-hint: "Describe the Azure platform engineering project you want to build end-to-end"
 ---
 

--- a/.github/prompts/resume-workflow.prompt.md
+++ b/.github/prompts/resume-workflow.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: "Resume the multi-step workflow from where it left off by reading session state and routing to the correct agent."
 agent: "01-Orchestrator"
-model: "GPT-5.4"
+model: "Claude Opus 4.6"
 ---
 
 # Resume Workflow
@@ -50,15 +50,15 @@ The agent reads `00-session-state.json` to determine:
 The workflow graph uses hyphenated node IDs; the session state JSON uses quoted string keys.
 Step 3_5 (Governance) uses underscores in both systems to avoid `parseInt("3.5")` issues.
 
-| Graph Node ID | State Steps Key | State review_audit Key | Agent                  | Condition                          |
-| ------------- | --------------- | ---------------------- | ---------------------- | ---------------------------------- |
-| `step-1`      | `"1"`           | `step_1`               | 02-Requirements        | —                                  |
-| `step-2`      | `"2"`           | `step_2`               | 03-Architect           | —                                  |
-| `step-3`      | `"3"`           | (none — optional)      | 04-Design              | optional                           |
-| `step-3_5`    | `"3_5"`         | `step_3_5`             | 04g-Governance         | —                                  |
-| `step-4`      | `"4"`           | `step_4`               | 05-IaC Planner         | —                                  |
-| `step-5b`     | `"5"`           | `step_5`               | 06b-Bicep CodeGen      | `decisions.iac_tool == "Bicep"`    |
-| `step-5t`     | `"5"`           | `step_5`               | 06t-Terraform CodeGen  | `decisions.iac_tool == "Terraform"`|
-| `step-6b`     | `"6"`           | `step_6`               | 07b-Bicep Deploy       | `decisions.iac_tool == "Bicep"`    |
-| `step-6t`     | `"6"`           | `step_6`               | 07t-Terraform Deploy   | `decisions.iac_tool == "Terraform"`|
-| `step-7`      | `"7"`           | (none)                 | 08-As-Built            | —                                  |
+| Graph Node ID | State Steps Key | State review_audit Key | Agent                 | Condition                           |
+| ------------- | --------------- | ---------------------- | --------------------- | ----------------------------------- |
+| `step-1`      | `"1"`           | `step_1`               | 02-Requirements       | —                                   |
+| `step-2`      | `"2"`           | `step_2`               | 03-Architect          | —                                   |
+| `step-3`      | `"3"`           | (none — optional)      | 04-Design             | optional                            |
+| `step-3_5`    | `"3_5"`         | `step_3_5`             | 04g-Governance        | —                                   |
+| `step-4`      | `"4"`           | `step_4`               | 05-IaC Planner        | —                                   |
+| `step-5b`     | `"5"`           | `step_5`               | 06b-Bicep CodeGen     | `decisions.iac_tool == "Bicep"`     |
+| `step-5t`     | `"5"`           | `step_5`               | 06t-Terraform CodeGen | `decisions.iac_tool == "Terraform"` |
+| `step-6b`     | `"6"`           | `step_6`               | 07b-Bicep Deploy      | `decisions.iac_tool == "Bicep"`     |
+| `step-6t`     | `"6"`           | `step_6`               | 07t-Terraform Deploy  | `decisions.iac_tool == "Terraform"` |
+| `step-7`      | `"7"`           | (none)                 | 08-As-Built           | —                                   |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- feat(agents): model realignment v2 — Orchestrator moves GPT-5.4 → Claude Opus 4.6;
+  CodeGen agents (06b-Bicep CodeGen, 06t-Terraform CodeGen) move GPT-5.4 → Claude Sonnet 4.6;
+  bicep/terraform subagents (bicep-validate, bicep-whatif, terraform-validate, terraform-plan)
+  move Claude Sonnet 4.6 → GPT-5.4. Claude XML directive blocks added to orchestrator and
+  codegen agents per model-prompt alignment rules. Agent-registry.json and authoring
+  instructions updated to match.
 - feat(agents): update model assignments for 9 agents/subagents.
   Codegen agents (06b-Bicep CodeGen, 06t-Terraform CodeGen) and deploy agents
   (07b-Bicep Deploy, 07t-Terraform Deploy) move from Claude Sonnet 4.6 → GPT-5.4.

--- a/site/src/content/docs/concepts/how-it-works/agents.md
+++ b/site/src/content/docs/concepts/how-it-works/agents.md
@@ -12,7 +12,7 @@ Every agent definition follows a standard structure:
 ---
 name: 06b-Bicep CodeGen
 description: Expert Azure Bicep IaC specialist...
-model: ["GPT-5.4"] # (1)!
+model: ["Claude Sonnet 4.6"] # (1)!
 tools: [list of allowed tools] # (2)!
 handoffs:
   - label: "Step 6: Deploy"
@@ -184,8 +184,9 @@ Model selection depends on the task. Use `.github/agent-registry.json` as the
 source of truth, but the current repo pattern is:
 
 - **Planning agents** (accuracy-first) — typically `Claude Opus 4.6`
-- **Execution and deploy agents** — typically `GPT-5.4`
-- **Validation and preview subagents** — currently `Claude Sonnet 4.6`
+- **Orchestrator** — `Claude Opus 4.6` for deep reasoning across the full workflow
+- **Code generation agents** — `Claude Sonnet 4.6` for balanced code quality and speed
+- **Execution, deploy, and validation subagents** — typically `GPT-5.4`
 - **Adversarial review** — use a different model family than the artifact author when possible
 
 ### Step 2: Create the Agent File

--- a/site/src/content/docs/concepts/workflow.md
+++ b/site/src/content/docs/concepts/workflow.md
@@ -142,9 +142,9 @@ preview subagents before any Azure changes are applied.
 
 ### Primary Orchestrator
 
-| Agent            | Codename        | Role                                        | Model   |
-| ---------------- | --------------- | ------------------------------------------- | ------- |
-| **Orchestrator** | 🧠 Orchestrator | Master orchestrator for multi-step workflow | GPT-5.4 |
+| Agent            | Codename        | Role                                        | Model           |
+| ---------------- | --------------- | ------------------------------------------- | --------------- |
+| **Orchestrator** | 🧠 Orchestrator | Master orchestrator for multi-step workflow | Claude Opus 4.6 |
 
 ### Core Agents (by Workflow Step)
 

--- a/site/src/content/docs/project/changelog.md
+++ b/site/src/content/docs/project/changelog.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- feat(agents): model realignment v2 — Orchestrator moves GPT-5.4 → Claude Opus 4.6;
+  CodeGen agents (06b-Bicep CodeGen, 06t-Terraform CodeGen) move GPT-5.4 → Claude Sonnet 4.6;
+  bicep/terraform subagents (bicep-validate, bicep-whatif, terraform-validate, terraform-plan)
+  move Claude Sonnet 4.6 → GPT-5.4. Claude XML directive blocks added to orchestrator and
+  codegen agents per model-prompt alignment rules. Agent-registry.json and authoring
+  instructions updated to match.
 - feat(agents): update model assignments for 9 agents/subagents.
   Codegen agents (06b-Bicep CodeGen, 06t-Terraform CodeGen) and deploy agents
   (07b-Bicep Deploy, 07t-Terraform Deploy) move from Claude Sonnet 4.6 → GPT-5.4.


### PR DESCRIPTION
## Summary

Realigns model assignments across the agent fleet per the v2 model strategy. Orchestrator moves to the highest-capability Claude model; IaC code generation agents move to Claude Sonnet 4.6 for strong reasoning with lower latency; execution/validation subagents move to GPT-5.4 for fast, deterministic output.

Also fixes a pre-existing registry mismatch on `e2e-orchestrator` discovered during review.

---

## Agent model changes (7 in-scope)

| Agent | Before | After |
|---|---|---|
| `01-Orchestrator` | GPT-5.4 | **Claude Opus 4.6** |
| `06b-Bicep CodeGen` | GPT-5.4 | **Claude Sonnet 4.6** |
| `06t-Terraform CodeGen` | GPT-5.4 | **Claude Sonnet 4.6** |
| `bicep-validate-subagent` | Claude Sonnet 4.6 | **GPT-5.4** |
| `bicep-whatif-subagent` | Claude Sonnet 4.6 | **GPT-5.4** |
| `terraform-validate-subagent` | Claude Sonnet 4.6 | **GPT-5.4** |
| `terraform-plan-subagent` | Claude Sonnet 4.6 | **GPT-5.4** |

## Prompt pattern alignment

Per `agent-authoring.instructions.md`:

- **Claude agents** (Orchestrator, Bicep/TF CodeGen): Added XML semantic directive blocks (`<context_awareness>`, `<subagent_budget>`, `<investigate_before_answering>`, `<scope_fencing>`, `<output_contract>`) and `<!-- Recommended reasoning_effort -->` HTML comments
- **GPT subagents**: No body changes — already use GPT-style markdown/table formatting

## Registry & config

- `agent-registry.json`: 8 model entries updated (7 in-scope + `e2e-orchestrator` pre-existing fix)
- `agent-authoring.instructions.md`: Model assignment table + group descriptions updated
- `01-orchestrator.prompt.md` + `resume-workflow.prompt.md`: Fixed stale `GPT-5.4` → `Claude Opus 4.6` (caught by `lint:agent-frontmatter`)

## Documentation

- `agents.md`: Model descriptions + example frontmatter updated
- `workflow.md`: Orchestrator row model column updated
- Both changelogs: New entry under `[0.10.0] Unreleased`

---

## Validation

```
lint:agent-frontmatter  →  0 errors, 0 warnings ✅
validate:agent-registry →  0 errors, 0 warnings ✅
lint:json               →  all files valid ✅
validate:all            →  0 errors across all checks ✅
pre-push diff checks    →  3 passed, 0 failed ✅
```