### PR TITLE
Fix devcontainer Deno and shell startup behavior

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -146,7 +146,7 @@
         },
         "markdownlint.run": "onSave",
         "deno.enable": false,
-        "deno.enablePaths": ["${workspaceFolder}/mcp/drawio-mcp-server"],
+        "deno.enablePaths": ["mcp/drawio-mcp-server"],
         "deno.lint": true,
         "deno.unstable": []
       }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -97,13 +97,20 @@ fi
 # ─── Step 4: Deno upgrade ─────────────────────────────────────────────────────
 # The devcontainer feature caches the image layer, so "version: latest" may
 # lag behind. Explicitly upgrade to ensure we always have the latest release.
+# Falls back to curl installer if `deno upgrade` fails (e.g. corrupt binary,
+# GitHub API rate limit during feature install).
 
 step_start "🦕" "Upgrading Deno to latest..."
 if command -v deno &>/dev/null; then
     if sudo deno upgrade 2>&1 | tail -1; then
         step_done "deno $(deno --version 2>/dev/null | head -n1 | awk '{print $2}')"
     else
-        step_warn "Deno upgrade failed — using feature-installed version"
+        # Fallback: install from official script if upgrade fails
+        if curl -fsSL https://deno.land/install.sh | sudo DENO_INSTALL=/usr/local sh 2>&1 | tail -1; then
+            step_done "deno $(deno --version 2>/dev/null | head -n1 | awk '{print $2}') (fresh install)"
+        else
+            step_warn "Deno upgrade and fresh install both failed — using feature-installed version"
+        fi
     fi
     # Pre-cache drawio MCP server dependencies to eliminate first-start latency.
     # Must run from the project dir so deno.json import map is resolved correctly.
@@ -120,9 +127,11 @@ fi
 # ─── Step 5: Directories & Git ───────────────────────────────────────────────
 
 step_start "🔐" "Configuring Git & directories..."
-mkdir -p "${HOME}/.cache" "${HOME}/.cache/deno" "${HOME}/.config/gh"
+sudo mkdir -p "${HOME}/.cache" "${HOME}/.cache/deno" "${HOME}/.config/gh" \
+              "${HOME}/.local/share/powershell/PSReadLine"
 sudo chown -R vscode:vscode "${HOME}/.cache" 2>/dev/null || true
 sudo chown -R vscode:vscode "${HOME}/.config/gh" 2>/dev/null || true
+sudo chown -R vscode:vscode "${HOME}/.local/share" 2>/dev/null || true
 chmod 755 "${HOME}/.cache" 2>/dev/null || true
 chmod 755 "${HOME}/.config/gh" 2>/dev/null || true
 git config --global --add safe.directory "${PWD}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,7 +49,7 @@
   "python.terminal.useEnvFile": true,
   "azureTerraform.checkTerraformCmd": false,
   "deno.enable": false,
-  "deno.enablePaths": ["${workspaceFolder}/mcp/drawio-mcp-server"],
+  "deno.enablePaths": ["mcp/drawio-mcp-server"],
   "deno.lint": true,
   "deno.unstable": [],
   "workbench.editorAssociations": {


### PR DESCRIPTION
## Summary
- switch Deno extension enable paths to the relative `mcp/drawio-mcp-server` path in workspace and devcontainer settings
- harden Deno setup in `.devcontainer/post-create.sh` with a fallback fresh install when `deno upgrade` fails
- create and permission the PowerShell PSReadLine history directory during container setup to avoid startup history write errors

## Validation
- `bash -n .devcontainer/post-create.sh`
- `npm run validate:vscode`
- executed the Deno upgrade step from `.devcontainer/post-create.sh` successfully
- verified push-time diff-based checks passed