### PR TITLE
ci: upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: site
       - run: npm run build
         working-directory: site
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site/dist
 
@@ -50,4 +50,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/e2e-validation.yml
+++ b/.github/workflows/e2e-validation.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload benchmark reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-benchmark-reports
           path: |

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -133,7 +133,7 @@ jobs:
             }
 
       - name: Upload version report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: avm-version-report
           path: |


### PR DESCRIPTION
## Summary

Bumps three GitHub Actions from v4 to v5 to resolve Node.js 20 deprecation warnings.

### Changes

| Action | From | To | Workflow |
|--------|------|----|----------|
| `actions/upload-artifact` | v4 | v5 | weekly-maintenance.yml, e2e-validation.yml |
| `actions/upload-pages-artifact` | v4 | v5 | docs.yml |
| `actions/deploy-pages` | v4 | v5 | docs.yml |

### Why

GitHub is forcing Node.js 24 for all Actions starting June 2, 2026, and removing Node.js 20 support on September 16, 2026. The v4 versions of these actions run on Node.js 20 and produce CI deprecation warnings.

v5 of each action adds Node.js 24 support, resolving the warnings.