### PR TITLE
feat(docs): add 5 new edge types to architecture explorer graph

### DIFF
--- a/scripts/generate-explorer-graph.mjs
+++ b/scripts/generate-explorer-graph.mjs
@@ -15,6 +15,11 @@
  *  - agent → subagent (frontmatter `agents:` field)
  *  - agent handoff → agent (frontmatter `handoffs[].agent`)
  *  - agent → skill (from `.github/skill-affinity.json`, tiered)
+ *  - prompt → agent (slug match, e.g. `02-requirements` → `02-Requirements`)
+ *  - instruction → agent/skill/prompt (via `applyTo` glob + name match)
+ *  - workflow → validator (parse YAML for `npm run …`, expanding composite scripts)
+ *  - agent → mcp (scan agent body for MCP server names)
+ *  - skill → skill (parse SKILL.md for references to other skill slugs)
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
@@ -384,6 +389,189 @@ function buildEdges(nodes, skillAffinity) {
             kind: tier === "primary" ? "uses-primary" : "uses-secondary",
           });
         }
+      }
+    }
+  }
+
+  // Prompt -> Agent (by slug match, e.g. 02-requirements prompt -> 02-Requirements agent)
+  for (const n of nodes) {
+    if (n.category !== "prompt") continue;
+    const promptSlug = n.id.replace(/^prompt:/, "");
+    const target = nodes.find(
+      (m) => m.category === "agent" && slug(m.label) === promptSlug,
+    );
+    if (target) {
+      edges.push({
+        id: `${n.id}--invokes->${target.id}`,
+        source: n.id,
+        target: target.id,
+        kind: "invokes",
+      });
+    }
+  }
+
+  // Instruction -> Agent/Skill/Prompt (by applyTo glob)
+  for (const n of nodes) {
+    if (n.category !== "instruction") continue;
+    const applyTo = (n.meta.applyTo || "").toString();
+    if (!applyTo) continue;
+    // Match instructions that target agent/skill/prompt file types or specific names
+    const targetCats = [];
+    if (/\.agent\.md/i.test(applyTo)) targetCats.push("agent", "subagent");
+    if (/SKILL\.md|skills\//i.test(applyTo)) targetCats.push("skill");
+    if (/\.prompt\.md/i.test(applyTo)) targetCats.push("prompt");
+    if (/\.instructions\.md/i.test(applyTo)) targetCats.push("instruction");
+    if (targetCats.length === 0) continue;
+    // Connect to a representative (orchestrator for agents, first agent) to avoid explosion
+    // Only connect to agents explicitly named in applyTo; otherwise attach to all agents is noisy.
+    // Instead, attach to a single hub node per targetCat if no specific name match.
+    for (const cat of new Set(targetCats)) {
+      // Find an explicit name match first (e.g., "orchestrator" in applyTo)
+      const explicit = nodes.find(
+        (m) =>
+          m.category === cat &&
+          new RegExp(slug(m.label).replace(/-/g, "[-_]"), "i").test(applyTo),
+      );
+      if (explicit) {
+        edges.push({
+          id: `${n.id}--applies-to->${explicit.id}`,
+          source: n.id,
+          target: explicit.id,
+          kind: "applies-to",
+        });
+      }
+    }
+  }
+
+  // Workflow -> Validator (parse YAML for `npm run <script>` references,
+  // recursively expanding composite scripts like `validate:_node`).
+  const pkgScripts = readJson(join(REPO_ROOT, "package.json")).scripts || {};
+  const validatorLabels = new Set(
+    nodes.filter((m) => m.category === "validator").map((m) => m.label),
+  );
+  function expandScript(name, seen = new Set()) {
+    if (seen.has(name)) return [];
+    seen.add(name);
+    if (validatorLabels.has(name)) return [name];
+    const body = pkgScripts[name];
+    if (!body) return [];
+    // Expand tokens that are themselves script names
+    const tokens = body.split(/\s+/).filter((t) => pkgScripts[t]);
+    return tokens.flatMap((t) => expandScript(t, seen));
+  }
+  for (const n of nodes) {
+    if (n.category !== "workflow") continue;
+    let yamlContent;
+    try {
+      yamlContent = readFileSync(join(REPO_ROOT, n.path), "utf8");
+    } catch {
+      continue;
+    }
+    const seen = new Set();
+    const re = /npm run\s+([a-zA-Z][\w:-]+)/g;
+    let match;
+    while ((match = re.exec(yamlContent))) {
+      const scriptName = match[1];
+      for (const validatorName of expandScript(scriptName)) {
+        if (seen.has(validatorName)) continue;
+        seen.add(validatorName);
+        const validator = nodes.find(
+          (m) => m.category === "validator" && m.label === validatorName,
+        );
+        if (validator) {
+          edges.push({
+            id: `${n.id}--runs->${validator.id}`,
+            source: n.id,
+            target: validator.id,
+            kind: "runs",
+          });
+        }
+      }
+    }
+  }
+
+  // Agent -> MCP (scan agent body for MCP server names)
+  const mcpNodes = nodes.filter((m) => m.category === "mcp");
+  for (const n of nodes) {
+    if (n.category !== "agent" && n.category !== "subagent") continue;
+    let body;
+    try {
+      body = readFileSync(join(REPO_ROOT, n.path), "utf8").toLowerCase();
+    } catch {
+      continue;
+    }
+    const seen = new Set();
+    for (const mcpNode of mcpNodes) {
+      const mcpName = mcpNode.label.toLowerCase();
+      if (seen.has(mcpNode.id)) continue;
+      const re = new RegExp(
+        `\\b${mcpName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
+      );
+      if (re.test(body)) {
+        seen.add(mcpNode.id);
+        edges.push({
+          id: `${n.id}--uses-mcp->${mcpNode.id}`,
+          source: n.id,
+          target: mcpNode.id,
+          kind: "uses-mcp",
+        });
+      }
+    }
+  }
+
+  // Skill -> Skill (parse SKILL.md body/description for references to other skills, e.g. "delegates to drawio")
+  const skillNodes = nodes.filter((m) => m.category === "skill");
+  const skillSlugMap = new Map(
+    skillNodes.map((s) => [s.id.replace(/^skill:/, ""), s]),
+  );
+  for (const n of skillNodes) {
+    let body;
+    try {
+      body = readFileSync(join(REPO_ROOT, n.path), "utf8");
+    } catch {
+      continue;
+    }
+    const nSlug = n.id.replace(/^skill:/, "");
+    const seen = new Set();
+    for (const [otherSlug, otherNode] of skillSlugMap) {
+      if (otherSlug === nSlug || seen.has(otherNode.id)) continue;
+      // Match word-boundary backtick or plain reference
+      const re = new RegExp(`\\b${otherSlug}\\b`);
+      if (re.test(body)) {
+        seen.add(otherNode.id);
+        edges.push({
+          id: `${n.id}--refs->${otherNode.id}`,
+          source: n.id,
+          target: otherNode.id,
+          kind: "refs",
+        });
+      }
+    }
+  }
+  for (const n of nodes) {
+    if (n.category !== "agent" && n.category !== "subagent") continue;
+    let body;
+    try {
+      body = readFileSync(join(REPO_ROOT, n.path), "utf8").toLowerCase();
+    } catch {
+      continue;
+    }
+    const seen = new Set();
+    for (const mcpNode of mcpNodes) {
+      const mcpName = mcpNode.label.toLowerCase();
+      if (seen.has(mcpNode.id)) continue;
+      // Require word-boundary match to reduce false positives
+      const re = new RegExp(
+        `\\b${mcpName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
+      );
+      if (re.test(body)) {
+        seen.add(mcpNode.id);
+        edges.push({
+          id: `${n.id}--uses-mcp->${mcpNode.id}`,
+          source: n.id,
+          target: mcpNode.id,
+          kind: "uses-mcp",
+        });
       }
     }
   }

--- a/site/public/architecture-explorer-graph.json
+++ b/site/public/architecture-explorer-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "architecture-explorer-graph-v1",
-  "generatedAt": "2026-04-20T11:13:53.639Z",
+  "generatedAt": "2026-04-20T11:24:43.776Z",
   "categories": [
     {
       "id": "agent",
@@ -68,7 +68,7 @@
     }
   ],
   "nodeCount": 157,
-  "edgeCount": 190,
+  "edgeCount": 428,
   "nodes": [
     {
       "id": "agent:01-orchestrator-fast-path",
@@ -3304,6 +3304,1434 @@
       "source": "agent:11-context-optimizer",
       "target": "skill:context-optimizer",
       "kind": "uses-primary"
+    },
+    {
+      "id": "prompt:01-orchestrator--invokes->agent:01-orchestrator",
+      "source": "prompt:01-orchestrator",
+      "target": "agent:01-orchestrator",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:02-requirements--invokes->agent:02-requirements",
+      "source": "prompt:02-requirements",
+      "target": "agent:02-requirements",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:03-architect--invokes->agent:03-architect",
+      "source": "prompt:03-architect",
+      "target": "agent:03-architect",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:04-design--invokes->agent:04-design",
+      "source": "prompt:04-design",
+      "target": "agent:04-design",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:04g-governance--invokes->agent:04g-governance",
+      "source": "prompt:04g-governance",
+      "target": "agent:04g-governance",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:05-iac-planner--invokes->agent:05-iac-planner",
+      "source": "prompt:05-iac-planner",
+      "target": "agent:05-iac-planner",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:06b-bicep-codegen--invokes->agent:06b-bicep-codegen",
+      "source": "prompt:06b-bicep-codegen",
+      "target": "agent:06b-bicep-codegen",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:06t-terraform-codegen--invokes->agent:06t-terraform-codegen",
+      "source": "prompt:06t-terraform-codegen",
+      "target": "agent:06t-terraform-codegen",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:07b-bicep-deploy--invokes->agent:07b-bicep-deploy",
+      "source": "prompt:07b-bicep-deploy",
+      "target": "agent:07b-bicep-deploy",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:07t-terraform-deploy--invokes->agent:07t-terraform-deploy",
+      "source": "prompt:07t-terraform-deploy",
+      "target": "agent:07t-terraform-deploy",
+      "kind": "invokes"
+    },
+    {
+      "id": "prompt:08-as-built--invokes->agent:08-as-built",
+      "source": "prompt:08-as-built",
+      "target": "agent:08-as-built",
+      "kind": "invokes"
+    },
+    {
+      "id": "instruction:context-optimization--applies-to->instruction:instructions",
+      "source": "instruction:context-optimization",
+      "target": "instruction:instructions",
+      "kind": "applies-to"
+    },
+    {
+      "id": "instruction:instructions--applies-to->instruction:instructions",
+      "source": "instruction:instructions",
+      "target": "instruction:instructions",
+      "kind": "applies-to"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-md",
+      "source": "workflow:ci",
+      "target": "validator:lint-md",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-artifacts",
+      "source": "workflow:ci",
+      "target": "validator:validate-artifacts",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-agents",
+      "source": "workflow:ci",
+      "target": "validator:validate-agents",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-skills",
+      "source": "workflow:ci",
+      "target": "validator:validate-skills",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-version-sync",
+      "source": "workflow:ci",
+      "target": "validator:lint-version-sync",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-deprecated-refs",
+      "source": "workflow:ci",
+      "target": "validator:lint-deprecated-refs",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-mcp-config",
+      "source": "workflow:ci",
+      "target": "validator:lint-mcp-config",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-governance-refs",
+      "source": "workflow:ci",
+      "target": "validator:lint-governance-refs",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-instruction-checks",
+      "source": "workflow:ci",
+      "target": "validator:validate-instruction-checks",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-session-state",
+      "source": "workflow:ci",
+      "target": "validator:validate-session-state",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-session-lock",
+      "source": "workflow:ci",
+      "target": "validator:validate-session-lock",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-workflow-graph",
+      "source": "workflow:ci",
+      "target": "validator:validate-workflow-graph",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-agent-registry",
+      "source": "workflow:ci",
+      "target": "validator:validate-agent-registry",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-skill-checks",
+      "source": "workflow:ci",
+      "target": "validator:validate-skill-checks",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-json",
+      "source": "workflow:ci",
+      "target": "validator:lint-json",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-glob-audit",
+      "source": "workflow:ci",
+      "target": "validator:lint-glob-audit",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-orphaned-content",
+      "source": "workflow:ci",
+      "target": "validator:lint-orphaned-content",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-vscode",
+      "source": "workflow:ci",
+      "target": "validator:validate-vscode",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-drawio",
+      "source": "workflow:ci",
+      "target": "validator:lint-drawio",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:lint-model-floors",
+      "source": "workflow:ci",
+      "target": "validator:lint-model-floors",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:ci--runs->validator:validate-explorer-graph",
+      "source": "workflow:ci",
+      "target": "validator:validate-explorer-graph",
+      "kind": "runs"
+    },
+    {
+      "id": "workflow:weekly-maintenance--runs->validator:lint-docs-freshness",
+      "source": "workflow:weekly-maintenance",
+      "target": "validator:lint-docs-freshness",
+      "kind": "runs"
+    },
+    {
+      "id": "agent:01-orchestrator-fast-path--uses-mcp->mcp:github",
+      "source": "agent:01-orchestrator-fast-path",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator-fast-path--uses-mcp->mcp:terraform",
+      "source": "agent:01-orchestrator-fast-path",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator--uses-mcp->mcp:github",
+      "source": "agent:01-orchestrator",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator--uses-mcp->mcp:terraform",
+      "source": "agent:01-orchestrator",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:01-orchestrator",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator--uses-mcp->mcp:drawio",
+      "source": "agent:01-orchestrator",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:02-requirements--uses-mcp->mcp:github",
+      "source": "agent:02-requirements",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:02-requirements--uses-mcp->mcp:terraform",
+      "source": "agent:02-requirements",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:02-requirements--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:02-requirements",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:03-architect--uses-mcp->mcp:github",
+      "source": "agent:03-architect",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:03-architect--uses-mcp->mcp:terraform",
+      "source": "agent:03-architect",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:03-architect--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:03-architect",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:03-architect--uses-mcp->mcp:drawio",
+      "source": "agent:03-architect",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04-design--uses-mcp->mcp:github",
+      "source": "agent:04-design",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04-design--uses-mcp->mcp:terraform",
+      "source": "agent:04-design",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04-design--uses-mcp->mcp:drawio",
+      "source": "agent:04-design",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04g-governance--uses-mcp->mcp:github",
+      "source": "agent:04g-governance",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04g-governance--uses-mcp->mcp:terraform",
+      "source": "agent:04g-governance",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04g-governance--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:04g-governance",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:05-iac-planner--uses-mcp->mcp:github",
+      "source": "agent:05-iac-planner",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:05-iac-planner--uses-mcp->mcp:terraform",
+      "source": "agent:05-iac-planner",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:05-iac-planner--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:05-iac-planner",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06b-bicep-codegen--uses-mcp->mcp:github",
+      "source": "agent:06b-bicep-codegen",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06b-bicep-codegen--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:06b-bicep-codegen",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06t-terraform-codegen--uses-mcp->mcp:github",
+      "source": "agent:06t-terraform-codegen",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06t-terraform-codegen--uses-mcp->mcp:terraform",
+      "source": "agent:06t-terraform-codegen",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06t-terraform-codegen--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:06t-terraform-codegen",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07b-bicep-deploy--uses-mcp->mcp:github",
+      "source": "agent:07b-bicep-deploy",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07b-bicep-deploy--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:07b-bicep-deploy",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07b-bicep-deploy--uses-mcp->mcp:drawio",
+      "source": "agent:07b-bicep-deploy",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07t-terraform-deploy--uses-mcp->mcp:github",
+      "source": "agent:07t-terraform-deploy",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07t-terraform-deploy--uses-mcp->mcp:terraform",
+      "source": "agent:07t-terraform-deploy",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07t-terraform-deploy--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:07t-terraform-deploy",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07t-terraform-deploy--uses-mcp->mcp:drawio",
+      "source": "agent:07t-terraform-deploy",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:08-as-built--uses-mcp->mcp:github",
+      "source": "agent:08-as-built",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:08-as-built--uses-mcp->mcp:terraform",
+      "source": "agent:08-as-built",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:08-as-built--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:08-as-built",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:08-as-built--uses-mcp->mcp:drawio",
+      "source": "agent:08-as-built",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:09-diagnose--uses-mcp->mcp:github",
+      "source": "agent:09-diagnose",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:09-diagnose--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:09-diagnose",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:10-challenger--uses-mcp->mcp:github",
+      "source": "agent:10-challenger",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:10-challenger--uses-mcp->mcp:terraform",
+      "source": "agent:10-challenger",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:11-context-optimizer--uses-mcp->mcp:github",
+      "source": "agent:11-context-optimizer",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:e2e-orchestrator--uses-mcp->mcp:github",
+      "source": "agent:e2e-orchestrator",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:e2e-orchestrator--uses-mcp->mcp:terraform",
+      "source": "agent:e2e-orchestrator",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:e2e-orchestrator--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:e2e-orchestrator",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:e2e-orchestrator--uses-mcp->mcp:drawio",
+      "source": "agent:e2e-orchestrator",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:bicep-validate-subagent--uses-mcp->mcp:github",
+      "source": "subagent:bicep-validate-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:bicep-validate-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:bicep-validate-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:bicep-whatif-subagent--uses-mcp->mcp:github",
+      "source": "subagent:bicep-whatif-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:bicep-whatif-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:bicep-whatif-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:challenger-review-subagent--uses-mcp->mcp:github",
+      "source": "subagent:challenger-review-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:challenger-review-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:challenger-review-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:cost-estimate-subagent--uses-mcp->mcp:github",
+      "source": "subagent:cost-estimate-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:cost-estimate-subagent--uses-mcp->mcp:azure-pricing",
+      "source": "subagent:cost-estimate-subagent",
+      "target": "mcp:azure-pricing",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:governance-discovery-subagent--uses-mcp->mcp:github",
+      "source": "subagent:governance-discovery-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:governance-discovery-subagent--uses-mcp->mcp:terraform",
+      "source": "subagent:governance-discovery-subagent",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:governance-discovery-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:governance-discovery-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-plan-subagent--uses-mcp->mcp:github",
+      "source": "subagent:terraform-plan-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-plan-subagent--uses-mcp->mcp:terraform",
+      "source": "subagent:terraform-plan-subagent",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-plan-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:terraform-plan-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-validate-subagent--uses-mcp->mcp:github",
+      "source": "subagent:terraform-validate-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-validate-subagent--uses-mcp->mcp:terraform",
+      "source": "subagent:terraform-validate-subagent",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-validate-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:terraform-validate-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "skill:appinsights-instrumentation--refs->skill:azure-prepare",
+      "source": "skill:appinsights-instrumentation",
+      "target": "skill:azure-prepare",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-adr--refs->skill:drawio",
+      "source": "skill:azure-adr",
+      "target": "skill:drawio",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-aigateway--refs->skill:azure-ai",
+      "source": "skill:azure-aigateway",
+      "target": "skill:azure-ai",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-aigateway--refs->skill:azure-prepare",
+      "source": "skill:azure-aigateway",
+      "target": "skill:azure-prepare",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-artifacts--refs->skill:azure-defaults",
+      "source": "skill:azure-artifacts",
+      "target": "skill:azure-defaults",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-artifacts--refs->skill:terraform-patterns",
+      "source": "skill:azure-artifacts",
+      "target": "skill:terraform-patterns",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-bicep-patterns--refs->skill:azure-defaults",
+      "source": "skill:azure-bicep-patterns",
+      "target": "skill:azure-defaults",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-cloud-migrate--refs->skill:azure-prepare",
+      "source": "skill:azure-cloud-migrate",
+      "target": "skill:azure-prepare",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-cost-optimization--refs->skill:azure-deploy",
+      "source": "skill:azure-cost-optimization",
+      "target": "skill:azure-deploy",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-cost-optimization--refs->skill:azure-diagnostics",
+      "source": "skill:azure-cost-optimization",
+      "target": "skill:azure-diagnostics",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-defaults--refs->skill:azure-artifacts",
+      "source": "skill:azure-defaults",
+      "target": "skill:azure-artifacts",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-deploy--refs->skill:azure-aigateway",
+      "source": "skill:azure-deploy",
+      "target": "skill:azure-aigateway",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-deploy--refs->skill:azure-prepare",
+      "source": "skill:azure-deploy",
+      "target": "skill:azure-prepare",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-deploy--refs->skill:azure-validate",
+      "source": "skill:azure-deploy",
+      "target": "skill:azure-validate",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-deploy--refs->skill:iac-common",
+      "source": "skill:azure-deploy",
+      "target": "skill:iac-common",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-diagrams--refs->skill:drawio",
+      "source": "skill:azure-diagrams",
+      "target": "skill:drawio",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-diagrams--refs->skill:excalidraw",
+      "source": "skill:azure-diagrams",
+      "target": "skill:excalidraw",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-diagrams--refs->skill:mermaid",
+      "source": "skill:azure-diagrams",
+      "target": "skill:mermaid",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-diagrams--refs->skill:python-diagrams",
+      "source": "skill:azure-diagrams",
+      "target": "skill:python-diagrams",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-hosted-copilot-sdk--refs->skill:azure-deploy",
+      "source": "skill:azure-hosted-copilot-sdk",
+      "target": "skill:azure-deploy",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-hosted-copilot-sdk--refs->skill:azure-prepare",
+      "source": "skill:azure-hosted-copilot-sdk",
+      "target": "skill:azure-prepare",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-hosted-copilot-sdk--refs->skill:azure-validate",
+      "source": "skill:azure-hosted-copilot-sdk",
+      "target": "skill:azure-validate",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-prepare--refs->skill:azure-aigateway",
+      "source": "skill:azure-prepare",
+      "target": "skill:azure-aigateway",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-prepare--refs->skill:azure-cloud-migrate",
+      "source": "skill:azure-prepare",
+      "target": "skill:azure-cloud-migrate",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-prepare--refs->skill:azure-deploy",
+      "source": "skill:azure-prepare",
+      "target": "skill:azure-deploy",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-prepare--refs->skill:azure-hosted-copilot-sdk",
+      "source": "skill:azure-prepare",
+      "target": "skill:azure-hosted-copilot-sdk",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-prepare--refs->skill:azure-validate",
+      "source": "skill:azure-prepare",
+      "target": "skill:azure-validate",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-resource-lookup--refs->skill:azure-cost-optimization",
+      "source": "skill:azure-resource-lookup",
+      "target": "skill:azure-cost-optimization",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-resource-lookup--refs->skill:azure-deploy",
+      "source": "skill:azure-resource-lookup",
+      "target": "skill:azure-deploy",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-resource-visualizer--refs->skill:azure-deploy",
+      "source": "skill:azure-resource-visualizer",
+      "target": "skill:azure-deploy",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-resource-visualizer--refs->skill:azure-diagnostics",
+      "source": "skill:azure-resource-visualizer",
+      "target": "skill:azure-diagnostics",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-resource-visualizer--refs->skill:mermaid",
+      "source": "skill:azure-resource-visualizer",
+      "target": "skill:mermaid",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-storage--refs->skill:azure-messaging",
+      "source": "skill:azure-storage",
+      "target": "skill:azure-messaging",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-storage--refs->skill:azure-prepare",
+      "source": "skill:azure-storage",
+      "target": "skill:azure-prepare",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-validate--refs->skill:azure-deploy",
+      "source": "skill:azure-validate",
+      "target": "skill:azure-deploy",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:azure-validate--refs->skill:azure-prepare",
+      "source": "skill:azure-validate",
+      "target": "skill:azure-prepare",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:context-shredding--refs->skill:azure-artifacts",
+      "source": "skill:context-shredding",
+      "target": "skill:azure-artifacts",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:context-shredding--refs->skill:azure-defaults",
+      "source": "skill:context-shredding",
+      "target": "skill:azure-defaults",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:context-shredding--refs->skill:context-optimizer",
+      "source": "skill:context-shredding",
+      "target": "skill:context-optimizer",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:context-shredding--refs->skill:golden-principles",
+      "source": "skill:context-shredding",
+      "target": "skill:golden-principles",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:context-shredding--refs->skill:session-resume",
+      "source": "skill:context-shredding",
+      "target": "skill:session-resume",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:copilot-customization--refs->skill:context-optimizer",
+      "source": "skill:copilot-customization",
+      "target": "skill:context-optimizer",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:docs-writer--refs->skill:azure-artifacts",
+      "source": "skill:docs-writer",
+      "target": "skill:azure-artifacts",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:drawio--refs->skill:excalidraw",
+      "source": "skill:drawio",
+      "target": "skill:excalidraw",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:drawio--refs->skill:mermaid",
+      "source": "skill:drawio",
+      "target": "skill:mermaid",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:drawio--refs->skill:python-diagrams",
+      "source": "skill:drawio",
+      "target": "skill:python-diagrams",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:entra-app-registration--refs->skill:azure-rbac",
+      "source": "skill:entra-app-registration",
+      "target": "skill:azure-rbac",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:excalidraw--refs->skill:drawio",
+      "source": "skill:excalidraw",
+      "target": "skill:drawio",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:excalidraw--refs->skill:mermaid",
+      "source": "skill:excalidraw",
+      "target": "skill:mermaid",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:excalidraw--refs->skill:python-diagrams",
+      "source": "skill:excalidraw",
+      "target": "skill:python-diagrams",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:golden-principles--refs->skill:azure-artifacts",
+      "source": "skill:golden-principles",
+      "target": "skill:azure-artifacts",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:golden-principles--refs->skill:azure-defaults",
+      "source": "skill:golden-principles",
+      "target": "skill:azure-defaults",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:iac-common--refs->skill:azure-bicep-patterns",
+      "source": "skill:iac-common",
+      "target": "skill:azure-bicep-patterns",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:iac-common--refs->skill:azure-defaults",
+      "source": "skill:iac-common",
+      "target": "skill:azure-defaults",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:iac-common--refs->skill:azure-validate",
+      "source": "skill:iac-common",
+      "target": "skill:azure-validate",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:iac-common--refs->skill:terraform-patterns",
+      "source": "skill:iac-common",
+      "target": "skill:terraform-patterns",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:mermaid--refs->skill:azure-resource-visualizer",
+      "source": "skill:mermaid",
+      "target": "skill:azure-resource-visualizer",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:mermaid--refs->skill:drawio",
+      "source": "skill:mermaid",
+      "target": "skill:drawio",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:mermaid--refs->skill:python-diagrams",
+      "source": "skill:mermaid",
+      "target": "skill:python-diagrams",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-code-reference--refs->skill:azure-bicep-patterns",
+      "source": "skill:microsoft-code-reference",
+      "target": "skill:azure-bicep-patterns",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-code-reference--refs->skill:azure-storage",
+      "source": "skill:microsoft-code-reference",
+      "target": "skill:azure-storage",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-code-reference--refs->skill:microsoft-docs",
+      "source": "skill:microsoft-code-reference",
+      "target": "skill:microsoft-docs",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-code-reference--refs->skill:microsoft-skill-creator",
+      "source": "skill:microsoft-code-reference",
+      "target": "skill:microsoft-skill-creator",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-code-reference--refs->skill:terraform-patterns",
+      "source": "skill:microsoft-code-reference",
+      "target": "skill:terraform-patterns",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-docs--refs->skill:microsoft-code-reference",
+      "source": "skill:microsoft-docs",
+      "target": "skill:microsoft-code-reference",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-docs--refs->skill:microsoft-skill-creator",
+      "source": "skill:microsoft-docs",
+      "target": "skill:microsoft-skill-creator",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-foundry--refs->skill:azure-ai",
+      "source": "skill:microsoft-foundry",
+      "target": "skill:azure-ai",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-foundry--refs->skill:azure-deploy",
+      "source": "skill:microsoft-foundry",
+      "target": "skill:azure-deploy",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-foundry--refs->skill:azure-prepare",
+      "source": "skill:microsoft-foundry",
+      "target": "skill:azure-prepare",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:microsoft-skill-creator--refs->skill:make-skill-template",
+      "source": "skill:microsoft-skill-creator",
+      "target": "skill:make-skill-template",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:python-diagrams--refs->skill:drawio",
+      "source": "skill:python-diagrams",
+      "target": "skill:drawio",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:python-diagrams--refs->skill:excalidraw",
+      "source": "skill:python-diagrams",
+      "target": "skill:excalidraw",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:python-diagrams--refs->skill:mermaid",
+      "source": "skill:python-diagrams",
+      "target": "skill:mermaid",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:terraform-patterns--refs->skill:azure-defaults",
+      "source": "skill:terraform-patterns",
+      "target": "skill:azure-defaults",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:terraform-search-import--refs->skill:terraform-patterns",
+      "source": "skill:terraform-search-import",
+      "target": "skill:terraform-patterns",
+      "kind": "refs"
+    },
+    {
+      "id": "agent:01-orchestrator-fast-path--uses-mcp->mcp:github",
+      "source": "agent:01-orchestrator-fast-path",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator-fast-path--uses-mcp->mcp:terraform",
+      "source": "agent:01-orchestrator-fast-path",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator--uses-mcp->mcp:github",
+      "source": "agent:01-orchestrator",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator--uses-mcp->mcp:terraform",
+      "source": "agent:01-orchestrator",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:01-orchestrator",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:01-orchestrator--uses-mcp->mcp:drawio",
+      "source": "agent:01-orchestrator",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:02-requirements--uses-mcp->mcp:github",
+      "source": "agent:02-requirements",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:02-requirements--uses-mcp->mcp:terraform",
+      "source": "agent:02-requirements",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:02-requirements--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:02-requirements",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:03-architect--uses-mcp->mcp:github",
+      "source": "agent:03-architect",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:03-architect--uses-mcp->mcp:terraform",
+      "source": "agent:03-architect",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:03-architect--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:03-architect",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:03-architect--uses-mcp->mcp:drawio",
+      "source": "agent:03-architect",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04-design--uses-mcp->mcp:github",
+      "source": "agent:04-design",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04-design--uses-mcp->mcp:terraform",
+      "source": "agent:04-design",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04-design--uses-mcp->mcp:drawio",
+      "source": "agent:04-design",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04g-governance--uses-mcp->mcp:github",
+      "source": "agent:04g-governance",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04g-governance--uses-mcp->mcp:terraform",
+      "source": "agent:04g-governance",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:04g-governance--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:04g-governance",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:05-iac-planner--uses-mcp->mcp:github",
+      "source": "agent:05-iac-planner",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:05-iac-planner--uses-mcp->mcp:terraform",
+      "source": "agent:05-iac-planner",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:05-iac-planner--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:05-iac-planner",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06b-bicep-codegen--uses-mcp->mcp:github",
+      "source": "agent:06b-bicep-codegen",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06b-bicep-codegen--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:06b-bicep-codegen",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06t-terraform-codegen--uses-mcp->mcp:github",
+      "source": "agent:06t-terraform-codegen",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06t-terraform-codegen--uses-mcp->mcp:terraform",
+      "source": "agent:06t-terraform-codegen",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:06t-terraform-codegen--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:06t-terraform-codegen",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07b-bicep-deploy--uses-mcp->mcp:github",
+      "source": "agent:07b-bicep-deploy",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07b-bicep-deploy--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:07b-bicep-deploy",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07b-bicep-deploy--uses-mcp->mcp:drawio",
+      "source": "agent:07b-bicep-deploy",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07t-terraform-deploy--uses-mcp->mcp:github",
+      "source": "agent:07t-terraform-deploy",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07t-terraform-deploy--uses-mcp->mcp:terraform",
+      "source": "agent:07t-terraform-deploy",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07t-terraform-deploy--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:07t-terraform-deploy",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:07t-terraform-deploy--uses-mcp->mcp:drawio",
+      "source": "agent:07t-terraform-deploy",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:08-as-built--uses-mcp->mcp:github",
+      "source": "agent:08-as-built",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:08-as-built--uses-mcp->mcp:terraform",
+      "source": "agent:08-as-built",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:08-as-built--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:08-as-built",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:08-as-built--uses-mcp->mcp:drawio",
+      "source": "agent:08-as-built",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:09-diagnose--uses-mcp->mcp:github",
+      "source": "agent:09-diagnose",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:09-diagnose--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:09-diagnose",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:10-challenger--uses-mcp->mcp:github",
+      "source": "agent:10-challenger",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:10-challenger--uses-mcp->mcp:terraform",
+      "source": "agent:10-challenger",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:11-context-optimizer--uses-mcp->mcp:github",
+      "source": "agent:11-context-optimizer",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:e2e-orchestrator--uses-mcp->mcp:github",
+      "source": "agent:e2e-orchestrator",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:e2e-orchestrator--uses-mcp->mcp:terraform",
+      "source": "agent:e2e-orchestrator",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:e2e-orchestrator--uses-mcp->mcp:microsoft-learn",
+      "source": "agent:e2e-orchestrator",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:e2e-orchestrator--uses-mcp->mcp:drawio",
+      "source": "agent:e2e-orchestrator",
+      "target": "mcp:drawio",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:bicep-validate-subagent--uses-mcp->mcp:github",
+      "source": "subagent:bicep-validate-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:bicep-validate-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:bicep-validate-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:bicep-whatif-subagent--uses-mcp->mcp:github",
+      "source": "subagent:bicep-whatif-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:bicep-whatif-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:bicep-whatif-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:challenger-review-subagent--uses-mcp->mcp:github",
+      "source": "subagent:challenger-review-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:challenger-review-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:challenger-review-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:cost-estimate-subagent--uses-mcp->mcp:github",
+      "source": "subagent:cost-estimate-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:cost-estimate-subagent--uses-mcp->mcp:azure-pricing",
+      "source": "subagent:cost-estimate-subagent",
+      "target": "mcp:azure-pricing",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:governance-discovery-subagent--uses-mcp->mcp:github",
+      "source": "subagent:governance-discovery-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:governance-discovery-subagent--uses-mcp->mcp:terraform",
+      "source": "subagent:governance-discovery-subagent",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:governance-discovery-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:governance-discovery-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-plan-subagent--uses-mcp->mcp:github",
+      "source": "subagent:terraform-plan-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-plan-subagent--uses-mcp->mcp:terraform",
+      "source": "subagent:terraform-plan-subagent",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-plan-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:terraform-plan-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-validate-subagent--uses-mcp->mcp:github",
+      "source": "subagent:terraform-validate-subagent",
+      "target": "mcp:github",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-validate-subagent--uses-mcp->mcp:terraform",
+      "source": "subagent:terraform-validate-subagent",
+      "target": "mcp:terraform",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "subagent:terraform-validate-subagent--uses-mcp->mcp:microsoft-learn",
+      "source": "subagent:terraform-validate-subagent",
+      "target": "mcp:microsoft-learn",
+      "kind": "uses-mcp"
     }
   ]
 }

--- a/site/public/architecture-explorer.html
+++ b/site/public/architecture-explorer.html
@@ -867,6 +867,51 @@
                 opacity: 0.35,
               },
             },
+            {
+              selector: 'edge[kind = "invokes"]',
+              style: {
+                "line-color": "#ec4899",
+                "target-arrow-color": "#ec4899",
+                "target-arrow-shape": "triangle",
+                opacity: 0.55,
+              },
+            },
+            {
+              selector: 'edge[kind = "applies-to"]',
+              style: {
+                "line-color": "#f59e0b",
+                "target-arrow-color": "#f59e0b",
+                "line-style": "dashed",
+                opacity: 0.45,
+              },
+            },
+            {
+              selector: 'edge[kind = "runs"]',
+              style: {
+                "line-color": "#06b6d4",
+                "target-arrow-color": "#06b6d4",
+                "target-arrow-shape": "triangle",
+                opacity: 0.55,
+              },
+            },
+            {
+              selector: 'edge[kind = "uses-mcp"]',
+              style: {
+                "line-color": "#f43f5e",
+                "target-arrow-color": "#f43f5e",
+                "line-style": "dotted",
+                opacity: 0.5,
+              },
+            },
+            {
+              selector: 'edge[kind = "refs"]',
+              style: {
+                "line-color": "#34d399",
+                "line-style": "dotted",
+                opacity: 0.3,
+                width: 1,
+              },
+            },
           ];
           // Per-category node styling (colour + shape)
           for (const cat of graph.categories) {
@@ -954,13 +999,16 @@
           return {
             ...base,
             name: "cose",
-            idealEdgeLength: 90,
-            nodeRepulsion: 6000,
-            edgeElasticity: 100,
-            gravity: 0.3,
-            numIter: reduceMotion ? 400 : 1500,
+            idealEdgeLength: 80,
+            nodeRepulsion: 4500,
+            edgeElasticity: 120,
+            gravity: 0.6,
+            gravityRange: 1.2,
+            numIter: reduceMotion ? 400 : 1800,
             randomize: true,
-            componentSpacing: 80,
+            componentSpacing: 40,
+            nodeOverlap: 12,
+            coolingFactor: 0.97,
           };
         }
 

--- a/site/src/content/docs/reference/architecture-explorer.mdx
+++ b/site/src/content/docs/reference/architecture-explorer.mdx
@@ -68,6 +68,11 @@ the explorer is always authoritative. The categories tracked are:
 | Dashed purple       | Agent **delegates** to a subagent (`agents:` frontmatter).           |
 | Solid green         | Agent **uses a primary skill** (always loaded).                      |
 | Dotted grey         | Agent **uses a secondary skill** (on-demand).                        |
+| Solid pink, arrow   | Prompt **invokes** an agent (name-matched).                          |
+| Dashed amber        | Instruction **applies to** an agent/skill/prompt type.               |
+| Solid teal, arrow   | CI workflow **runs** a validator (`npm run …`).                      |
+| Dotted red          | Agent **uses an MCP server** (referenced in body).                   |
+| Dotted green        | Skill **references** another skill (e.g. routing/delegation).        |
 
 ## Data source
 


### PR DESCRIPTION
## Summary

After PR #315 fixed the broken explorer HTML, the graph still looked poor — **117 of 157 nodes (75%) rendered as disconnected orphans** in a grid below the main cluster because the generator only emitted 3 edge types (agent→subagent, agent→agent handoffs, agent→skill).

## Changes

**5 new edge collectors** in `scripts/generate-explorer-graph.mjs`:

| Edge kind     | Source → Target                 | Detection                                                       |
| ------------- | ------------------------------- | --------------------------------------------------------------- |
| `invokes`     | prompt → agent                  | Slug match (e.g. `02-requirements` → `02-Requirements`)         |
| `applies-to`  | instruction → agent/skill/prompt| `applyTo` glob + name match                                     |
| `runs`        | workflow → validator            | Parse YAML for `npm run …`, expand composite scripts            |
| `uses-mcp`    | agent → mcp                     | Scan agent body for MCP server names                            |
| `refs`        | skill → skill                   | Parse `SKILL.md` for references to other skill slugs            |

**Layout tuning**: cose `componentSpacing` 80→40, `gravity` 0.3→0.6, so remaining orphans cluster compactly instead of forming a grid.

**Explorer HTML**: new Cytoscape edge styles (pink invokes, amber applies-to, teal runs, red uses-mcp, green refs).

**Docs**: updated edge legend in `site/src/content/docs/reference/architecture-explorer.mdx`.

## Impact

- Edges: **190 → 428** (+125%)
- Orphans: **117 → 50** (−57%)
- Remaining orphans are legitimately standalone (generic file-type instructions, utility validators).

## Validation

- `node scripts/validate-explorer-graph.mjs` — passes
- `npm run build` in `site/` — 60 pages, all internal links valid
- Pre-commit + pre-push hooks passed