### PR TITLE
chore(eslint): close adoption loop — fix 9 residual findings + 6 prettier diffs

### DIFF
--- a/tools/scripts/fetch-vendor-prompting-guides.mjs
+++ b/tools/scripts/fetch-vendor-prompting-guides.mjs
@@ -111,7 +111,7 @@ async function fetchGithub(source) {
       { encoding: "utf-8" },
     );
     return { ok: true, body: out, method: "gh-api" };
-  } catch (e) {
+  } catch (_e) {
     // Fall back to anonymous raw
     const url = `https://raw.githubusercontent.com/${source.repo}/${source.ref}/${source.apiPath}`;
     const result = await fetchAnonymous({ url });
@@ -189,7 +189,7 @@ async function main() {
     }
   }
 
-  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+  fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
 
   // Update source-freshness manifest
   fs.mkdirSync(path.dirname(FRESHNESS_MANIFEST), { recursive: true });
@@ -216,7 +216,7 @@ async function main() {
     if (existing >= 0) freshness.sources[existing] = fresh;
     else freshness.sources.push(fresh);
   }
-  fs.writeFileSync(FRESHNESS_MANIFEST, JSON.stringify(freshness, null, 2) + "\n", "utf-8");
+  fs.writeFileSync(FRESHNESS_MANIFEST, `${JSON.stringify(freshness, null, 2)}\n`, "utf-8");
 
   console.log(`\nSnapshots: ${SNAPSHOT_DIR}`);
   console.log(`Manifest:  ${MANIFEST_PATH}`);

--- a/tools/scripts/generate-explorer-graph.mjs
+++ b/tools/scripts/generate-explorer-graph.mjs
@@ -31,14 +31,10 @@ import { parseFrontmatter } from "./_lib/parse-frontmatter.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(__filename), "../..");
-const OUT_PATH = join(
-  REPO_ROOT,
-  "site/public/architecture-explorer-graph.json",
-);
+const OUT_PATH = join(REPO_ROOT, "site/public/architecture-explorer-graph.json");
 
-const GITHUB_BASE =
-  "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/";
-const DOCS_BASE = "/azure-agentic-infraops/";
+const GITHUB_BASE = "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/";
+const _DOCS_BASE = "/azure-agentic-infraops/";
 
 /** @type {Array<{id: string, key: string, label: string, color: string, shape: string}>} */
 const CATEGORIES = [
@@ -178,9 +174,7 @@ function collectSkills() {
   const skillsDir = join(REPO_ROOT, ".github/skills");
   let dirs = [];
   try {
-    dirs = readdirSync(skillsDir).filter((d) =>
-      statSync(join(skillsDir, d)).isDirectory(),
-    );
+    dirs = readdirSync(skillsDir).filter((d) => statSync(join(skillsDir, d)).isDirectory());
   } catch {
     return [];
   }
@@ -246,10 +240,7 @@ function collectPrompts() {
 
 function collectWorkflows() {
   const dir = join(REPO_ROOT, ".github/workflows");
-  const files = listFiles(
-    dir,
-    (f) => f.endsWith(".yml") || f.endsWith(".yaml"),
-  );
+  const files = listFiles(dir, (f) => f.endsWith(".yml") || f.endsWith(".yaml"));
   return files.map((path) => {
     const name = basename(path).replace(/\.(yml|yaml)$/, "");
     return {
@@ -286,7 +277,7 @@ function collectValidators() {
     description: scripts[name] || "",
     path: "package.json",
     links: {
-      source: GITHUB_BASE + "package.json",
+      source: `${GITHUB_BASE}package.json`,
     },
     meta: { command: scripts[name] || "" },
   }));
@@ -299,10 +290,9 @@ function collectMcpServers() {
     id: `mcp:${slug(name)}`,
     category: "mcp",
     label: name,
-    description:
-      cfg.type === "http" ? `HTTP: ${cfg.url}` : `stdio: ${cfg.command || ""}`,
+    description: cfg.type === "http" ? `HTTP: ${cfg.url}` : `stdio: ${cfg.command || ""}`,
     path: ".vscode/mcp.json",
-    links: { source: GITHUB_BASE + ".vscode/mcp.json" },
+    links: { source: `${GITHUB_BASE}.vscode/mcp.json` },
     meta: { type: cfg.type || "" },
   }));
 }
@@ -333,9 +323,7 @@ function buildEdges(nodes) {
 
   const findNode = (name, category) => {
     // Try exact label, then slug match, optionally scoped by category.
-    const candidates = [byLabel.get(name), bySlug.get(slug(name))].filter(
-      Boolean,
-    );
+    const candidates = [byLabel.get(name), bySlug.get(slug(name))].filter(Boolean);
     if (category) {
       const scoped = candidates.find((c) => c.category === category);
       if (scoped) return scoped;
@@ -387,9 +375,7 @@ function buildEdges(nodes) {
   for (const n of nodes) {
     if (n.category !== "prompt") continue;
     const promptSlug = n.id.replace(/^prompt:/, "");
-    const target = nodes.find(
-      (m) => m.category === "agent" && slug(m.label) === promptSlug,
-    );
+    const target = nodes.find((m) => m.category === "agent" && slug(m.label) === promptSlug);
     if (target) {
       edges.push({
         id: `${n.id}--invokes->${target.id}`,
@@ -423,13 +409,9 @@ function buildEdges(nodes) {
         (m) =>
           m.category === cat &&
           m.id !== n.id &&
-          new RegExp(`\\b${slug(m.label).replace(/-/g, "[-_]")}\\b`, "i").test(
-            applyTo,
-          ),
+          new RegExp(`\\b${slug(m.label).replace(/-/g, "[-_]")}\\b`, "i").test(applyTo),
       );
-      const targets = explicit
-        ? [explicit]
-        : nodes.filter((m) => m.category === cat && m.id !== n.id);
+      const targets = explicit ? [explicit] : nodes.filter((m) => m.category === cat && m.id !== n.id);
       for (const t of targets) {
         edges.push({
           id: `${n.id}--applies-to->${t.id}`,
@@ -444,9 +426,7 @@ function buildEdges(nodes) {
   // Workflow -> Validator (parse YAML for `npm run <script>` references,
   // recursively expanding composite scripts like `validate:_node`).
   const pkgScripts = readJson(join(REPO_ROOT, "package.json")).scripts || {};
-  const validatorLabels = new Set(
-    nodes.filter((m) => m.category === "validator").map((m) => m.label),
-  );
+  const validatorLabels = new Set(nodes.filter((m) => m.category === "validator").map((m) => m.label));
   function expandScript(name, seen = new Set()) {
     if (seen.has(name)) return [];
     seen.add(name);
@@ -473,9 +453,7 @@ function buildEdges(nodes) {
       for (const validatorName of expandScript(scriptName)) {
         if (seen.has(validatorName)) continue;
         seen.add(validatorName);
-        const validator = nodes.find(
-          (m) => m.category === "validator" && m.label === validatorName,
-        );
+        const validator = nodes.find((m) => m.category === "validator" && m.label === validatorName);
         if (validator) {
           edges.push({
             id: `${n.id}--runs->${validator.id}`,
@@ -502,9 +480,7 @@ function buildEdges(nodes) {
     for (const mcpNode of mcpNodes) {
       const mcpName = mcpNode.label.toLowerCase();
       if (seen.has(mcpNode.id)) continue;
-      const re = new RegExp(
-        `\\b${mcpName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
-      );
+      const re = new RegExp(`\\b${mcpName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`);
       if (re.test(body)) {
         seen.add(mcpNode.id);
         edges.push({
@@ -519,9 +495,7 @@ function buildEdges(nodes) {
 
   // Skill -> Skill (parse SKILL.md body/description for references to other skills, e.g. "delegates to drawio")
   const skillNodes = nodes.filter((m) => m.category === "skill");
-  const skillSlugMap = new Map(
-    skillNodes.map((s) => [s.id.replace(/^skill:/, ""), s]),
-  );
+  const skillSlugMap = new Map(skillNodes.map((s) => [s.id.replace(/^skill:/, ""), s]));
   for (const n of skillNodes) {
     let body;
     try {
@@ -568,16 +542,7 @@ function main() {
   const workflows = collectWorkflows();
   const mcp = collectMcpServers();
 
-  const nodes = [
-    ...agents,
-    ...subagents,
-    ...skills,
-    ...instructions,
-    ...prompts,
-    ...validators,
-    ...workflows,
-    ...mcp,
-  ];
+  const nodes = [...agents, ...subagents, ...skills, ...instructions, ...prompts, ...validators, ...workflows, ...mcp];
 
   const edges = buildEdges(nodes);
 
@@ -632,13 +597,9 @@ function main() {
     edges,
   };
 
-  writeFileSync(OUT_PATH, JSON.stringify(graph, null, 2) + "\n");
-  console.log(
-    `✅ Generated ${relative(REPO_ROOT, OUT_PATH)} — ${nodes.length} nodes, ${edges.length} edges`,
-  );
-  console.log(
-    "   " + categories.map((c) => `${c.label}:${c.count}`).join("  "),
-  );
+  writeFileSync(OUT_PATH, `${JSON.stringify(graph, null, 2)}\n`);
+  console.log(`✅ Generated ${relative(REPO_ROOT, OUT_PATH)} — ${nodes.length} nodes, ${edges.length} edges`);
+  console.log(`   ${categories.map((c) => `${c.label}:${c.count}`).join("  ")}`);
 }
 
 main();

--- a/tools/scripts/safe-shell.mjs
+++ b/tools/scripts/safe-shell.mjs
@@ -35,16 +35,8 @@ const SCAN_GLOBS = [
   { dir: ".github/prompts", suffix: ".md" },
 ];
 // For skills, only the canonical SKILL files (not nested references/).
-const SKILL_FILE_NAMES = new Set([
-  "SKILL.md",
-  "SKILL.digest.md",
-  "SKILL.minimal.md",
-]);
-const SCAN_ROOT_FILES = [
-  "AGENTS.md",
-  "README.md",
-  ".github/copilot-instructions.md",
-];
+const SKILL_FILE_NAMES = new Set(["SKILL.md", "SKILL.digest.md", "SKILL.minimal.md"]);
+const SCAN_ROOT_FILES = ["AGENTS.md", "README.md", ".github/copilot-instructions.md"];
 
 // Each rule:
 //   id: short rule id for the report
@@ -211,14 +203,7 @@ function lintFile(absPath) {
     // Inside a fence, only scan shell-flavored fences. Other fences (json,
     // yaml, text, etc.) cannot be executed as shell commands.
     if (inFence) {
-      const SHELL_FENCES = new Set([
-        "",
-        "bash",
-        "sh",
-        "zsh",
-        "shell",
-        "console",
-      ]);
+      const SHELL_FENCES = new Set(["", "bash", "sh", "zsh", "shell", "console"]);
       if (!SHELL_FENCES.has(fenceLang)) return;
     }
     for (const rule of RULES) {
@@ -246,21 +231,15 @@ function main() {
     const rel = path.relative(ROOT, file);
     console.error(`\n❌ ${rel}`);
     for (const f of findings) {
-      console.error(
-        `   Line ${f.line} [${f.rule}]: ${f.snippet}\n     why: ${f.why}\n     fix: ${f.fix}`,
-      );
+      console.error(`   Line ${f.line} [${f.rule}]: ${f.snippet}\n     why: ${f.why}\n     fix: ${f.fix}`);
     }
   }
   if (totalViolations === 0) {
     console.log(`✅ safe-shell: scanned ${files.length} files, 0 violations`);
     process.exit(0);
   }
-  console.error(
-    `\n❌ safe-shell: ${totalViolations} violation(s) across ${files.length} files`,
-  );
-  console.error(
-    "   See .github/instructions/no-interactive-shell.instructions.md for the full ruleset.",
-  );
+  console.error(`\n❌ safe-shell: ${totalViolations} violation(s) across ${files.length} files`);
+  console.error("   See .github/instructions/no-interactive-shell.instructions.md for the full ruleset.");
   process.exit(1);
 }
 

--- a/tools/scripts/validate-orphaned-content.mjs
+++ b/tools/scripts/validate-orphaned-content.mjs
@@ -11,11 +11,7 @@
  */
 
 import fs from "node:fs";
-import {
-  getAgents,
-  getSkills,
-  getInstructions,
-} from "./_lib/workspace-index.mjs";
+import { getAgents, getSkills, getInstructions } from "./_lib/workspace-index.mjs";
 import { Reporter } from "./_lib/reporter.mjs";
 import { COPILOT_INSTRUCTIONS } from "./_lib/paths.mjs";
 
@@ -62,11 +58,7 @@ function gatherReferenceContent() {
   }
 
   // Top-level config files
-  for (const f of [
-    COPILOT_INSTRUCTIONS,
-    "AGENTS.md",
-    ".github/prompts/plan-agenticWorkflowOverhaul.prompt.md",
-  ]) {
+  for (const f of [COPILOT_INSTRUCTIONS, "AGENTS.md", ".github/prompts/plan-agenticWorkflowOverhaul.prompt.md"]) {
     if (fs.existsSync(f)) corpus.push(fs.readFileSync(f, "utf-8"));
   }
 
@@ -87,8 +79,7 @@ const { corpus, perSkill } = gatherReferenceContent();
 //   - .github/skills/{name}/SKILL.digest.md
 //   - .github/skills/{name}/SKILL.minimal.md
 // (skills/{name}/SKILL[.tier].md without the leading .github/ also matches.)
-const SKILL_REFERENCE_PATTERN =
-  /(?:\.github\/)?skills\/([a-z0-9]+(?:-[a-z0-9]+)*)\/SKILL(?:\.digest|\.minimal)?\.md/g;
+const SKILL_REFERENCE_PATTERN = /(?:\.github\/)?skills\/([a-z0-9]+(?:-[a-z0-9]+)*)\/SKILL(?:\.digest|\.minimal)?\.md/g;
 
 function findSkillReferences(searchContent) {
   const found = new Set();
@@ -111,7 +102,7 @@ for (const [skill] of skills) {
     .filter(([name]) => name !== skill)
     .map(([, content]) => content)
     .join("\n");
-  const searchContent = corpus + "\n" + otherSkills;
+  const searchContent = `${corpus}\n${otherSkills}`;
 
   // Primary check: explicit `Read .github/skills/{name}/SKILL[.digest|.minimal].md`
   // pattern. Falls back to less precise containment checks for non-canonical

--- a/tools/tests/fixtures/subagent-file-contract/cost-estimate.findings.json
+++ b/tools/tests/fixtures/subagent-file-contract/cost-estimate.findings.json
@@ -63,10 +63,7 @@
   ],
   "savings_status": "QUANTIFIED",
   "savings_reason": "RI eligible compute identified",
-  "eligible_strategies": [
-    "Reserved Instances (3yr)",
-    "Azure Hybrid Benefit (SQL)"
-  ],
+  "eligible_strategies": ["Reserved Instances (3yr)", "Azure Hybrid Benefit (SQL)"],
   "data_source": "Azure Pricing MCP",
   "queried_at": "2026-05-08T12:00:00Z",
   "confidence": "High",

--- a/tools/tests/orphan-skill-discovery.test.mjs
+++ b/tools/tests/orphan-skill-discovery.test.mjs
@@ -15,8 +15,7 @@ import assert from "node:assert/strict";
 // Mirror of SKILL_REFERENCE_PATTERN in
 // tools/scripts/validate-orphaned-content.mjs. Keep in sync — the fixture
 // test exists specifically to detect drift in the regex.
-const SKILL_REFERENCE_PATTERN =
-  /(?:\.github\/)?skills\/([a-z0-9]+(?:-[a-z0-9]+)*)\/SKILL(?:\.digest|\.minimal)?\.md/g;
+const SKILL_REFERENCE_PATTERN = /(?:\.github\/)?skills\/([a-z0-9]+(?:-[a-z0-9]+)*)\/SKILL(?:\.digest|\.minimal)?\.md/g;
 
 function findSkillReferences(content) {
   const found = new Set();
@@ -45,12 +44,7 @@ describe("orphan-skill-discovery regex", () => {
   });
 
   it("finds references inside fenced code blocks", () => {
-    const content = [
-      "Run this:",
-      "```bash",
-      "cat .github/skills/microsoft-docs/SKILL.digest.md",
-      "```",
-    ].join("\n");
+    const content = ["Run this:", "```bash", "cat .github/skills/microsoft-docs/SKILL.digest.md", "```"].join("\n");
     assert.deepEqual([...findSkillReferences(content)], ["microsoft-docs"]);
   });
 
@@ -84,10 +78,7 @@ describe("orphan-skill-discovery regex", () => {
 
   it("matches kebab-case skill names", () => {
     const content = `Read .github/skills/azure-cost-optimization/SKILL.md`;
-    assert.deepEqual(
-      [...findSkillReferences(content)],
-      ["azure-cost-optimization"],
-    );
+    assert.deepEqual([...findSkillReferences(content)], ["azure-cost-optimization"]);
   });
 
   it("ignores uppercase / mixed-case skill names (must be kebab-case)", () => {

--- a/tools/tests/prompts/e2e-analyze-lessons.prompt.md
+++ b/tools/tests/prompts/e2e-analyze-lessons.prompt.md
@@ -13,13 +13,14 @@ multiple runs are selected, then produce **concrete, actionable improvements**
 to the agent/skill/validator/prompt system.
 
 <investigate_before_answering>
+
 - Lessons analysis depends on real telemetry. Before producing any
   recommendations, confirm: (a) which runs under `agent-output/` qualify
   (those containing `09-lessons-learned.json`); (b) whether a single run
   or multi-run merge is in scope; (c) the desired output project name.
 - If `08-benchmark-scores.json` is missing for a selected run, note the
   scoring gap and proceed with lessons-only analysis.
-</investigate_before_answering>
+  </investigate_before_answering>
 
 <context>
 - Source artifacts per run (under `agent-output/{run-name}/`):
@@ -41,7 +42,7 @@ Run the multi-step analysis described in the body below:
 4. Group findings by target (agent / skill / validator / prompt) and by
    recurrence.
 5. Produce a prioritised improvement plan with concrete edits per target.
-</task>
+   </task>
 
 <rules>
 - Use `askQuestions` for run selection — do not assume a single run.
@@ -56,6 +57,7 @@ Run the multi-step analysis described in the body below:
 </rules>
 
 <output_contract>
+
 - `agent-output/{output-project}/09-lessons-merged.json` (when multi-run)
 - `agent-output/{output-project}/08-benchmark-scores-combined.json` (when
   multi-run and per-run scores exist)
@@ -66,7 +68,7 @@ Run the multi-step analysis described in the body below:
   scores.
 - Summary returned to the user: top 5 highest-impact improvements + any
   recurring lessons.
-</output_contract>
+  </output_contract>
 
 ## Step 0 — Run Selection (Interactive)
 

--- a/tools/tests/subagent-file-contract.test.mjs
+++ b/tools/tests/subagent-file-contract.test.mjs
@@ -18,10 +18,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-const FIXTURE_DIR = new URL(
-  "./fixtures/subagent-file-contract/",
-  import.meta.url,
-).pathname;
+const FIXTURE_DIR = new URL("./fixtures/subagent-file-contract/", import.meta.url).pathname;
 
 const SUMMARY_BYTE_BUDGET = 2 * 1024;
 const SUMMARY_LINE_BUDGET = 15;
@@ -82,24 +79,13 @@ describe("subagent file-mode contract", () => {
 
     it("(a) summary stays within byte and line budgets", () => {
       const bytes = Buffer.byteLength(fixture.summary, "utf8");
-      const lines = fixture.summary
-        .split(/\r?\n/)
-        .filter((l) => l.length).length;
-      assert.ok(
-        bytes <= SUMMARY_BYTE_BUDGET,
-        `summary is ${bytes} bytes; budget is ${SUMMARY_BYTE_BUDGET}`,
-      );
-      assert.ok(
-        lines <= SUMMARY_LINE_BUDGET,
-        `summary has ${lines} non-empty lines; budget is ${SUMMARY_LINE_BUDGET}`,
-      );
+      const lines = fixture.summary.split(/\r?\n/).filter((l) => l.length).length;
+      assert.ok(bytes <= SUMMARY_BYTE_BUDGET, `summary is ${bytes} bytes; budget is ${SUMMARY_BYTE_BUDGET}`);
+      assert.ok(lines <= SUMMARY_LINE_BUDGET, `summary has ${lines} non-empty lines; budget is ${SUMMARY_LINE_BUDGET}`);
     });
 
     it("(b) the declared file_path exists post-call", () => {
-      const outputPath = path.join(
-        tmpDir,
-        "challenge-findings-architecture-pass1.json",
-      );
+      const outputPath = path.join(tmpDir, "challenge-findings-architecture-pass1.json");
       const result = simulateSubagentWrite({
         outputPath,
         payload: fixture.findings,
@@ -111,33 +97,14 @@ describe("subagent file-mode contract", () => {
 
     it("(c) summary numeric counts match the file content", () => {
       const summary = parseSummary(fixture.summary);
-      assert.equal(
-        summary.must_fix_count,
-        fixture.findings.must_fix_count,
-        "must_fix_count mismatch",
-      );
-      assert.equal(
-        summary.should_fix_count,
-        fixture.findings.should_fix_count,
-        "should_fix_count mismatch",
-      );
-      assert.equal(
-        summary.suggestion_count,
-        fixture.findings.suggestion_count,
-        "suggestion_count mismatch",
-      );
-      assert.equal(
-        summary.risk_level,
-        fixture.findings.risk_level,
-        "risk_level mismatch",
-      );
+      assert.equal(summary.must_fix_count, fixture.findings.must_fix_count, "must_fix_count mismatch");
+      assert.equal(summary.should_fix_count, fixture.findings.should_fix_count, "should_fix_count mismatch");
+      assert.equal(summary.suggestion_count, fixture.findings.suggestion_count, "suggestion_count mismatch");
+      assert.equal(summary.risk_level, fixture.findings.risk_level, "risk_level mismatch");
     });
 
     it("(d) re-running without overwrite: true is rejected", () => {
-      const outputPath = path.join(
-        tmpDir,
-        "challenge-findings-architecture-pass1-rerun.json",
-      );
+      const outputPath = path.join(tmpDir, "challenge-findings-architecture-pass1-rerun.json");
       // Initial write succeeds.
       const first = simulateSubagentWrite({
         outputPath,
@@ -166,9 +133,7 @@ describe("subagent file-mode contract", () => {
 
     it("(a) summary stays within byte and line budgets", () => {
       const bytes = Buffer.byteLength(fixture.summary, "utf8");
-      const lines = fixture.summary
-        .split(/\r?\n/)
-        .filter((l) => l.length).length;
+      const lines = fixture.summary.split(/\r?\n/).filter((l) => l.length).length;
       assert.ok(bytes <= SUMMARY_BYTE_BUDGET);
       assert.ok(lines <= SUMMARY_LINE_BUDGET);
     });
@@ -185,10 +150,7 @@ describe("subagent file-mode contract", () => {
 
     it("(c) summary totals match the file content", () => {
       const summary = parseSummary(fixture.summary);
-      assert.equal(
-        Number(summary.monthly_total.toString().replace(/[$,]/g, "")),
-        fixture.findings.monthly_total,
-      );
+      assert.equal(Number(summary.monthly_total.toString().replace(/[$,]/g, "")), fixture.findings.monthly_total);
       assert.equal(summary.region, fixture.findings.region);
       assert.equal(summary.status, fixture.findings.status);
     });

--- a/tools/tests/validate-agents/classify-model.test.mjs
+++ b/tools/tests/validate-agents/classify-model.test.mjs
@@ -10,18 +10,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import {
-  classifyModel,
-  isClaude,
-  isGpt55,
-  isGptFamily,
-} from "../../scripts/validate-agents.mjs";
+import { classifyModel, isClaude, isGpt55, isGptFamily } from "../../scripts/validate-agents.mjs";
 
 test("classifyModel: Claude Opus 4.7 → claude-opus", () => {
-  assert.equal(
-    classifyModel("Claude Opus 4.7"),
-    "claude-opus",
-  );
+  assert.equal(classifyModel("Claude Opus 4.7"), "claude-opus");
   assert.equal(classifyModel(["Claude Opus 4.7"]), "claude-opus");
 });
 


### PR DESCRIPTION
## Context

PR #349 squash-merged the ESLint+Prettier toolchain into `main` (`eslint.config.mjs`, `.prettierrc.json`, `.git-blame-ignore-revs`, lefthook hooks, CI safety net, 17 discovery artifacts under `agent-output/_plans/eslint-adoption/`).

However, other branches that landed in the same merge introduced new code that hadn't been linted. `npm run lint:js:ci` (newly wired into `validate:_node-ci`) currently **fails on `main`** with 9 findings.

This PR closes the loop.

## ESLint findings fixed

| File | Findings | Fix |
|------|----------|-----|
| `tools/scripts/fetch-vendor-prompting-guides.mjs` | 1× `no-unused-vars` (catch param), 2× `prefer-template` | auto-fix (`catch (e)` → `catch (_e)`; string concat → template literal) |
| `tools/scripts/generate-explorer-graph.mjs` | 1× `no-unused-vars` (`DOCS_BASE`), 4× `prefer-template` | auto-fix + manual underscore-prefix |
| `tools/scripts/validate-orphaned-content.mjs` | 1× `prefer-template` | auto-fix |

## Prettier diffs fixed

6 files that were dirty at the time of the original mass-reformat commit and got skipped:

- `tools/scripts/safe-shell.mjs`
- `tools/tests/fixtures/subagent-file-contract/cost-estimate.findings.json`
- `tools/tests/orphan-skill-discovery.test.mjs`
- `tools/tests/prompts/e2e-analyze-lessons.prompt.md`
- `tools/tests/subagent-file-contract.test.mjs`
- `tools/tests/validate-agents/classify-model.test.mjs`

## Verification

- `npm run lint:js -- --max-warnings=0 tools/scripts tools/tests` → exit 0, 0 bytes stdout (silent on green)
- `npm run lint:js:ci` → exit 0
- `npm run validate:_node-ci` → exit 0 (full CI gate)
- Smoke-tested affected scripts: `validate-orphaned-content.mjs` runs cleanly; `generate-explorer-graph.mjs` imports + regenerates the graph (171 nodes, 764 edges)

## Adopt-narrow status post-PR

With this merged, the loop is fully closed: every committed JS/MJS file in `tools/scripts/**` and `tools/tests/**` is both ESLint-clean and Prettier-clean, and `validate:_node-ci` enforces it. Pre-commit `lefthook` hooks (`js-lint` + `js-format`) catch new violations before they land.

Soft-enforce flag is still active: `--max-warnings=10000` in `lefthook.yml`. After the 1-week zero-new-finding window the implementation plan calls for, flip to `--max-warnings=0` (one-line edit).

## Related

- Discovery: [agent-output/_plans/eslint-adoption/findings.md](agent-output/_plans/eslint-adoption/findings.md)
- Implementation plan: [agent-output/_plans/eslint-adoption/implementation-plan.md](agent-output/_plans/eslint-adoption/implementation-plan.md)
- Predecessor: #349
