### PR TITLE
fix(context-window-followup): resolve 3 merge defects from PR #349

### DIFF
--- a/.github/agents/04-design.agent.md
+++ b/.github/agents/04-design.agent.md
@@ -205,7 +205,7 @@ For each non-trivial architectural decision in the architecture assessment:
 
 1. Read the relevant section of `02-architecture-assessment.md` and quote it
    in the ADR `## Context` section. Do not paraphrase from memory.
-2. Follow the format in `.github/skills/azure-adr/SKILL.md` (Context →
+2. Follow the format in `.github/skills/azure-adr/SKILL.digest.md` (Context →
    Decision → Consequences) and include WAF pillar trade-offs in the
    `## Decision` rationale.
 3. Number ADRs sequentially: `03-des-adr-0001-{slug}.md`,

--- a/.github/agents/_subagents/bicep-validate-subagent.agent.md
+++ b/.github/agents/_subagents/bicep-validate-subagent.agent.md
@@ -43,13 +43,14 @@ parent IaC agent.
 <context_awareness>
 Skill loading tiers (apply per the `context-shredding` skill):
 
-- ≤60% context — read full SKILL.md for `azure-defaults` and `iac-common`
-  (`.github/skills/azure-defaults/SKILL.md`,
-  `.github/skills/iac-common/SKILL.md`).
-- 60–80% — load `.github/skills/azure-defaults/SKILL.digest.md` and
-  `.github/skills/iac-common/SKILL.digest.md`.
-- ≥80% — load `.github/skills/azure-defaults/SKILL.minimal.md` and
+- Default — read `.github/skills/azure-defaults/SKILL.digest.md` and
+  `.github/skills/iac-common/SKILL.digest.md`. The digest is sufficient
+  for AVM versions, CAF naming, security baseline, and IaC review checks.
+- ≥80% context utilization — escalate to
+  `.github/skills/azure-defaults/SKILL.minimal.md` and
   `.github/skills/iac-common/SKILL.minimal.md`.
+- Full `SKILL.md` is reserved for skill-authoring or debugging contexts
+  where the digest is insufficient — not for production reviews.
 
 Read `04-governance-constraints.md` from `agent-output/{project}/` whenever
 the parent agent provides a project name; if absent, note the gap in findings

--- a/.github/agents/_subagents/challenger-review-subagent.agent.md
+++ b/.github/agents/_subagents/challenger-review-subagent.agent.md
@@ -42,21 +42,27 @@ caller-supplied `output_path` (atomic write, refuse-on-exists), and return only 
 Supports both single-lens and batch (multi-lens) execution modes.
 
 Role: Adversarial reviewer that runs one (or one batch of) review lens(es) over a single
-artifact and returns structured JSON findings to the parent agent.
+artifact, persists structured findings to the caller-supplied `output_path`,
+and returns only a compact summary to the parent agent. The full findings
+JSON never appears in the parent's chat context.
 
 # Goal
 
-Return a complete, parent-consumable findings payload for the requested
-lens(es) in a single invocation. The parent owns persistence; the subagent
-owns analysis.
+Persist a complete, parent-consumable findings JSON at the caller-supplied
+`output_path` (atomic write, refuse-on-exists) and emit a ≤15-line, ≤2 KB
+summary that lets the parent decide gates without loading the full payload.
 
 # Success criteria
 
-- Single-lens mode: one finding set whose schema matches the parent's
+- Single-lens mode: a single finding set whose schema matches the parent's
   expected fields (`challenged_artifact`, `artifact_type`, `review_focus`,
-  `risk_level`, `must_fix_count`, `should_fix_count`, `issues[]`).
-- Batch mode: one `batch_results` array, one entry per requested lens, in
-  the order provided.
+  `risk_level`, `must_fix_count`, `should_fix_count`, `issues[]`) is
+  written atomically to `output_path`.
+- Batch mode: a `batch_results` array (one entry per requested lens, in
+  the order provided) is written atomically to `output_path`.
+- The chat message returned to the parent is ≤15 lines and ≤2 KB and
+  carries `file_path`, `overall_assessment`, `risk_level`, and the
+  must/should/suggestion counts — never the full JSON.
 - `prior_findings` is consulted (when provided) to avoid duplicating
   issues across passes.
 - All claims verified against azure-defaults, iac-policy-compliance, and
@@ -64,25 +70,38 @@ owns analysis.
 
 # Constraints
 
-- Do not write files. The parent persists the JSON.
+- The output JSON file path MUST be supplied by the parent as `output_path`.
+  Do not invent or guess a path. If `output_path` is missing, fail fast.
+- Atomic write: write to `{output_path}.tmp` and then rename to
+  `{output_path}`. A partial canonical file must never appear on disk.
+- Refuse-on-exists: if the canonical file already exists and the parent did
+  NOT pass `overwrite: true`, fail fast with an explicit error and write
+  nothing.
 - Do not modify the challenged artifact.
+- Do not paste the full findings JSON to the parent. The parent reads
+  `output_path` from disk only when it needs the details.
 - Preserve the input contract (artifact_path, project_name, artifact_type,
-  review_focus, pass_number, prior_findings, batch_lenses) verbatim.
+  review_focus, pass_number, prior_findings, batch_lenses, output_path,
+  overwrite) verbatim.
 - Stay within the requested lens(es); do not silently expand scope.
 - Reasoning effort: rely on the Copilot runtime default. The checklist-
   driven workflow is structured I/O; elevated reasoning is unnecessary.
 
 # Output
 
-A single JSON payload (single-lens) or a `batch_results` array
-(batch mode), per the schema documented further down in this agent.
+**On disk** (`output_path`): a single JSON payload (single-lens) or a
+`batch_results` array (batch mode), per the schema documented further
+down in this agent.
+
+**To the parent** (chat message): the compact summary block defined in
+`## Parent-Facing Summary` below — limited to 15 lines and 2 KB.
 
 # Stop rules
 
-- Stop after producing the finding set (single-lens) or the
-  `batch_results` array (batch mode) and yield to the parent.
-- Stop and return an explicit error finding if a required input field
-  is missing or unrecognized; do not guess.
+- Stop after writing the canonical file and emitting the compact summary.
+- Stop and return an explicit error (no file written) if `output_path` is
+  missing, the target already exists without `overwrite: true`, or a
+  required input field is missing or unrecognized; do not guess.
 
 ## MANDATORY: Read Skills First
 

--- a/.github/agents/_subagents/terraform-validate-subagent.agent.md
+++ b/.github/agents/_subagents/terraform-validate-subagent.agent.md
@@ -43,13 +43,14 @@ PASS/FAIL diagnostic and verdict for the parent IaC agent.
 <context_awareness>
 Skill loading tiers (apply per the `context-shredding` skill):
 
-- ≤60% context — read full SKILL.md for `azure-defaults` and `iac-common`
-  (`.github/skills/azure-defaults/SKILL.md`,
-  `.github/skills/iac-common/SKILL.md`).
-- 60–80% — load `.github/skills/azure-defaults/SKILL.digest.md` and
-  `.github/skills/iac-common/SKILL.digest.md`.
-- ≥80% — load `.github/skills/azure-defaults/SKILL.minimal.md` and
+- Default — read `.github/skills/azure-defaults/SKILL.digest.md` and
+  `.github/skills/iac-common/SKILL.digest.md`. The digest is sufficient
+  for AVM versions, CAF naming, security baseline, and IaC review checks.
+- ≥80% context utilization — escalate to
+  `.github/skills/azure-defaults/SKILL.minimal.md` and
   `.github/skills/iac-common/SKILL.minimal.md`.
+- Full `SKILL.md` is reserved for skill-authoring or debugging contexts
+  where the digest is insufficient — not for production reviews.
 
 Read `04-governance-constraints.json` from `agent-output/{project}/`
 whenever the parent agent provides a project name; translate every

--- a/tools/scripts/validate-agent-registry.mjs
+++ b/tools/scripts/validate-agent-registry.mjs
@@ -4,8 +4,12 @@
  *
  * Validates tools/registry/agent-registry.json:
  * - All referenced .agent.md files exist
- * - All referenced skills exist in .github/skills/
  * - Cross-checks registry model strings against the agent YAML frontmatter
+ *
+ * Skill wiring is no longer carried by the registry — it is discovered at
+ * runtime via the orphan-content validator's regex sweep over agent bodies
+ * (`Read .github/skills/{name}/SKILL[.digest|.minimal].md`). See
+ * tools/scripts/validate-orphaned-content.mjs.
  *
  * Model allow-listing is intentionally NOT performed here. The agent frontmatter
  * is the canonical source of truth; this validator only confirms registry mirrors it.
@@ -16,26 +20,24 @@
  */
 
 import fs from "node:fs";
-import { getSkillNames, getAgents } from "./_lib/workspace-index.mjs";
+import { getAgents } from "./_lib/workspace-index.mjs";
 import { Reporter } from "./_lib/reporter.mjs";
 import { REGISTRY_PATH } from "./_lib/paths.mjs";
 
 const r = new Reporter("Agent Registry Validator");
 
-function validateAgentEntry(key, entry, skillNames) {
+function validateAgentEntry(key, entry) {
   // Handle IaC-conditional entries (bicep/terraform variants)
   if (entry.bicep || entry.terraform) {
     for (const variant of ["bicep", "terraform"]) {
       if (entry[variant]) {
         validateAgentFile(key, entry[variant].agent);
-        validateSkills(`${key} (${variant})`, entry[variant].skills, entry[variant].capability_skills, skillNames);
       }
     }
     return;
   }
 
   validateAgentFile(key, entry.agent);
-  validateSkills(key, entry.skills, entry.capability_skills, skillNames);
 }
 
 function validateAgentFile(key, agentPath) {
@@ -45,32 +47,6 @@ function validateAgentFile(key, agentPath) {
   }
   if (!fs.existsSync(agentPath)) {
     r.error(`Agent "${key}"`, `file not found: ${agentPath}`);
-  }
-}
-
-function validateSkills(key, skills, capabilitySkills, skillNames) {
-  if (!Array.isArray(skills)) return;
-  for (const skill of skills) {
-    if (!skillNames.has(skill)) {
-      r.error(`Agent "${key}"`, `references non-existent skill: "${skill}"`);
-    }
-  }
-  if (capabilitySkills !== undefined) {
-    if (!Array.isArray(capabilitySkills)) {
-      r.error(`Agent "${key}"`, "capability_skills must be an array");
-      return;
-    }
-    for (const skill of capabilitySkills) {
-      if (!skillNames.has(skill)) {
-        r.error(`Agent "${key}"`, `references non-existent capability skill: "${skill}"`);
-      }
-    }
-    const skillSet = new Set(skills);
-    for (const cap of capabilitySkills) {
-      if (skillSet.has(cap)) {
-        r.error(`Agent "${key}"`, `skill "${cap}" appears in both skills[] and capability_skills[]`);
-      }
-    }
   }
 }
 
@@ -97,13 +73,11 @@ try {
   process.exit(1);
 }
 
-const skillNames = getSkillNames();
-
 // Validate agents
 let agentCount = 0;
 if (registry.agents) {
   for (const [key, entry] of Object.entries(registry.agents)) {
-    validateAgentEntry(key, entry, skillNames);
+    validateAgentEntry(key, entry);
     agentCount++;
   }
 }
@@ -112,7 +86,7 @@ if (registry.agents) {
 let subagentCount = 0;
 if (registry.subagents) {
   for (const [key, entry] of Object.entries(registry.subagents)) {
-    validateAgentEntry(key, entry, skillNames);
+    validateAgentEntry(key, entry);
     subagentCount++;
   }
 }


### PR DESCRIPTION
## Summary

The squash-merge that landed the context-window-optimization plan (commit `ae47754`, PR #349) had three small but real defects that escaped review. This follow-up reconciles them.

A content-level audit of the work merged in #349 turned these up — see the audit summary in the conversation that produced this branch.

## Defects fixed

### 1. `challenger-review-subagent.agent.md` — contradicting contracts

The GPT-5.5 outcome-first skeleton sections (`# Goal`, `# Success criteria`, `# Constraints`, `# Output`, `# Stop rules`) still carried the **old** "do not write files; parent persists" contract while the rest of the file (`## Inputs`, `## File Write Protocol`, `## Parent-Facing Summary`) describes the **new** file-mode contract from Phase 1 of the plan.

Rewrote all five sections so they all align with `output_path` / atomic write / refuse-on-exists / compact summary.

### 2. `tools/scripts/validate-agent-registry.mjs` — dead skill code

Phase 2 of the plan called for dropping the `validateSkills` helper and the `getSkillNames` import after the registry stopped carrying `skills` / `capability_skills` arrays. The merge kept the dead code (no-op at runtime since the fields are absent — `validateSkills` short-circuits — but it contradicts the plan and confuses readers).

Dropped the helper, the import, and the call sites. Updated the module docstring to explain that skill wiring now lives in agent bodies, discovered by `validate-orphaned-content.mjs`.

### 3. SKILL.md (full) sweep gap — 5 references missed Phase 4's digest sweep

Three files still load the **full** `SKILL.md` even though the plan made `SKILL.digest.md` the default tier:

- `.github/agents/_subagents/bicep-validate-subagent.agent.md:45-50` — the `<context_awareness>` block prescribed the **old** tier rule (`≤60% → full SKILL.md`, `60–80% → digest`, `≥80% → minimal`).
- `.github/agents/_subagents/terraform-validate-subagent.agent.md:45-50` — same.
- `.github/agents/04-design.agent.md:208` — ADR format pointer was `azure-adr/SKILL.md`.

Updated all three to use `SKILL.digest.md` by default and rewrote the validate-subagent tier blocks to match the new rule documented in `context-shredding/SKILL.md`:

- **Default**: `SKILL.digest.md` (any utilization)
- **≥80% utilization** or explicit minimal-mode flag: `SKILL.minimal.md`
- **Full `SKILL.md`** is reserved for skill-authoring or debugging contexts only — not for production reviews.

## Validation

All checks green on this branch:

```
node tools/scripts/validate-agent-registry.mjs   → 0 errors / 0 warnings
npm run validate:agents                          → vendor-prompting + structural + alignment all pass
npm run lint:safe-shell                          → 227 files / 0 violations
npm run lint:js (scoped to edited .mjs)          → exit 0
node --test tools/tests/subagent-file-contract.test.mjs \
            tools/tests/orphan-skill-discovery.test.mjs → 17/17 pass
```

Pre-push hooks: branch-naming + branch-scope + diff-based-check — 5/5 passed.

## Diff size

5 files changed, +59 / −64.

```
.github/agents/04-design.agent.md                                 |   2 +-
.github/agents/_subagents/bicep-validate-subagent.agent.md        |  13 +++---
.github/agents/_subagents/challenger-review-subagent.agent.md     |  51 ++++++++++++++-------
.github/agents/_subagents/terraform-validate-subagent.agent.md    |  13 +++---
tools/scripts/validate-agent-registry.mjs                         |  44 ++++---------------
```

## Refs

- Plan: `agent-output/_plans/context-window-optimization/plan-contextWindowOptimization.prompt.md`
- Original merge: ae47754 (#349)
