### PR TITLE
fix(mcp): prevent drawio MCP startup failures when Deno JSR cache is empty

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -126,10 +126,13 @@ if command -v deno &>/dev/null; then
         fi
     fi
     # Pre-cache drawio MCP server dependencies to eliminate first-start latency.
-    # Must run from the project dir so deno.json import map is resolved correctly.
+    # Use `deno cache <entrypoint>` (canonical) so all transitive imports
+    # (JSR, npm, https) are pulled into $DENO_DIR. `deno install` (no args)
+    # only manages package.json-style deps and does NOT traverse JSR imports
+    # like @std/dotenv, which causes --cached-only startups to fail.
     DRAWIO_DIR="${PWD}/tools/mcp-servers/drawio"
     if [ -f "$DRAWIO_DIR/deno.json" ]; then
-        (cd "$DRAWIO_DIR" && deno install) 2>/dev/null \
+        (cd "$DRAWIO_DIR" && deno cache --frozen src/index.ts) >/dev/null 2>&1 \
             && printf "        ✅ drawio-mcp-server deps cached\n" \
             || printf "        ⚠️  drawio dep cache skipped\n"
     fi

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -44,9 +44,12 @@
         "run",
         "-P",
         "--no-check",
-        "--cached-only",
+        "--frozen",
         "${workspaceFolder}/tools/mcp-servers/drawio/src/index.ts"
-      ]
+      ],
+      "env": {
+        "DENO_DIR": "${userHome}/.cache/deno"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace drawio MCP launch flag from --cached-only to --frozen in .vscode/mcp.json
- Pin DENO_DIR in MCP config to ${userHome}/.cache/deno for deterministic cache path
- Update .devcontainer/post-create.sh to warm drawio deps using deno cache --frozen src/index.ts instead of deno install

## Why
The server frequently crashed with: JSR package manifest for @std/dotenv failed to load ... --cached-only is specified.

--cached-only hard-fails on cache misses. Combined with non-canonical warming (deno install), transitive JSR imports could be absent after cache eviction or rebuild, causing repeated startup failures.

## Validation
- Verified deno cache --frozen src/index.ts resolves and caches @std/dotenv
- Verified server starts cleanly with deno run -P --no-check --frozen tools/mcp-servers/drawio/src/index.ts
- Simulated empty JSR cache and confirmed server self-heals (downloads plus starts) with new config
