### PR TITLE
fix(devcontainer): rebuild azure-pricing venv on Python version drift

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -208,15 +208,36 @@ pwsh -NoProfile -Command "
 step_start "💰" "Setting up Azure Pricing MCP Server..."
 MCP_DIR="${PWD}/tools/mcp-servers/azure-pricing"
 if [ -d "$MCP_DIR" ]; then
-    if [ ! -f "$MCP_DIR/.venv/bin/pip" ]; then
+    # Detect a stale venv: created with a different Python minor (e.g. 3.13
+    # venv on a container upgraded to 3.14) leaves bin/pip orphaned because
+    # site-packages live under lib/python3.X/. Rebuild when version drifts
+    # or when ``python -m pip`` cannot import (covers both broken-pip and
+    # missing-venv cases).
+    SYS_PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+    VENV_PY_VER=""
+    if [ -f "$MCP_DIR/.venv/pyvenv.cfg" ]; then
+        VENV_PY_VER=$(grep -E '^version' "$MCP_DIR/.venv/pyvenv.cfg" 2>/dev/null \
+            | head -1 | awk '{print $3}' | cut -d'.' -f1-2)
+    fi
+    REBUILD_VENV=0
+    if [ ! -f "$MCP_DIR/.venv/bin/python" ]; then
+        REBUILD_VENV=1
+    elif [ -n "$VENV_PY_VER" ] && [ "$VENV_PY_VER" != "$SYS_PY_VER" ]; then
+        REBUILD_VENV=1
+    elif ! "$MCP_DIR/.venv/bin/python" -m pip --version >/dev/null 2>&1; then
+        REBUILD_VENV=1
+    fi
+    if [ "$REBUILD_VENV" -eq 1 ]; then
         rm -rf "$MCP_DIR/.venv" 2>/dev/null || true
         python3 -m venv "$MCP_DIR/.venv"
     fi
 
-    "$MCP_DIR/.venv/bin/pip" install --quiet --upgrade pip 2>&1 | tail -1 || true
+    "$MCP_DIR/.venv/bin/python" -m pip install --quiet --upgrade pip 2>&1 | tail -1 || true
 
     cd "$MCP_DIR"
-    "$MCP_DIR/.venv/bin/pip" install --quiet -e ".[azure]" 2>&1 | tail -1 || true
+    # ``[admin]`` is the canonical extras name (v5.x). ``[azure]`` is preserved
+    # as a deprecated alias for one release (removed in v6.0). Prefer admin.
+    "$MCP_DIR/.venv/bin/python" -m pip install --quiet -e ".[admin]" 2>&1 | tail -1 || true
     cd - > /dev/null
 
     if "$MCP_DIR/.venv/bin/python" -c "from azure_pricing_mcp import server; print('OK')" 2>/dev/null; then

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -46,12 +46,42 @@ fi
 
 # ─── Azure Pricing MCP ───────────────────────────────────────────────────────
 MCP_DIR="${WORKSPACE_FOLDER:-$PWD}/tools/mcp-servers/azure-pricing"
-if [ -f "$MCP_DIR/.venv/bin/pip" ]; then
-    "$MCP_DIR/.venv/bin/pip" install --quiet --upgrade pip 2>/dev/null || true
-    printf "    azure-pricing-mcp     "
-    "$MCP_DIR/.venv/bin/pip" install --quiet -e "$MCP_DIR[azure]" \
-        && printf "✅ updated\n" \
-        || printf "⚠️  update failed (continuing)\n"
+if [ -d "$MCP_DIR" ]; then
+    # Detect stale venv (Python minor mismatch after container upgrade) or
+    # broken pip. Rebuild rather than chasing a half-broken venv on every
+    # post-start run (post-create.sh has matching logic).
+    SYS_PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "")
+    VENV_PY_VER=""
+    if [ -f "$MCP_DIR/.venv/pyvenv.cfg" ]; then
+        VENV_PY_VER=$(grep -E '^version' "$MCP_DIR/.venv/pyvenv.cfg" 2>/dev/null \
+            | head -1 | awk '{print $3}' | cut -d'.' -f1-2)
+    fi
+    REBUILD_VENV=0
+    if [ ! -f "$MCP_DIR/.venv/bin/python" ]; then
+        REBUILD_VENV=1
+    elif [ -n "$VENV_PY_VER" ] && [ -n "$SYS_PY_VER" ] && [ "$VENV_PY_VER" != "$SYS_PY_VER" ]; then
+        REBUILD_VENV=1
+    elif ! "$MCP_DIR/.venv/bin/python" -m pip --version >/dev/null 2>&1; then
+        REBUILD_VENV=1
+    fi
+    if [ "$REBUILD_VENV" -eq 1 ]; then
+        printf "    azure-pricing-mcp     "
+        rm -rf "$MCP_DIR/.venv" 2>/dev/null || true
+        if python3 -m venv "$MCP_DIR/.venv" 2>/dev/null \
+            && "$MCP_DIR/.venv/bin/python" -m pip install --quiet --upgrade pip >/dev/null 2>&1 \
+            && "$MCP_DIR/.venv/bin/python" -m pip install --quiet -e "$MCP_DIR[admin]" >/dev/null 2>&1; then
+            printf "✅ rebuilt (Python version drift)\n"
+        else
+            printf "⚠️  rebuild failed (continuing)\n"
+        fi
+    elif [ -f "$MCP_DIR/.venv/bin/python" ]; then
+        "$MCP_DIR/.venv/bin/python" -m pip install --quiet --upgrade pip 2>/dev/null || true
+        printf "    azure-pricing-mcp     "
+        # ``[admin]`` is canonical (v5.x); ``[azure]`` is a deprecated alias.
+        "$MCP_DIR/.venv/bin/python" -m pip install --quiet -e "$MCP_DIR[admin]" \
+            && printf "✅ updated\n" \
+            || printf "⚠️  update failed (continuing)\n"
+    fi
 fi
 
 # ─── npm local dependencies ──────────────────────────────────────────────────


### PR DESCRIPTION
## Symptom

Reported on container rebuild after the base image was upgraded from Python 3.13 → 3.14:

```text
[8/14] 💰 Setting up Azure Pricing MCP Server...
ModuleNotFoundError: No module named 'pip'
ModuleNotFoundError: No module named 'pip'
        ⚠️  MCP server installed but health check failed (0s)
```

And on every subsequent `post-start.sh` run:

```text
azure-pricing-mcp     Traceback (most recent call last):
  File ".../tools/mcp-servers/azure-pricing/.venv/bin/pip", line 3, in <module>
    from pip._internal.cli.main import main
ModuleNotFoundError: No module named 'pip'
⚠️  update failed (continuing)
```

## Root Cause

Both `post-create.sh` and `post-start.sh` checked only for the existence of `.venv/bin/pip` before reusing the venv:

```bash
if [ ! -f "$MCP_DIR/.venv/bin/pip" ]; then
    rm -rf "$MCP_DIR/.venv"
    python3 -m venv "$MCP_DIR/.venv"
fi
```

When the container's Python was upgraded from 3.13 to 3.14:
- The venv's `lib/python3.13/site-packages` directory was kept
- `bin/python` symlinks to `/usr/local/python/current/bin/python3` now resolved to Python **3.14**
- The `pip` binary (a Python script) still existed (so the existence check passed)
- But `python -m pip` failed because no `pip` package exists at 3.14's site-packages path

Result: every install command ran with no functional pip, silently falling through to the failure handler.

## Fix

Detect **three** failure modes and rebuild the venv:

1. `bin/python` missing entirely (existing case)
2. `pyvenv.cfg` version field ≠ system Python minor (**new** — catches drift)
3. `python -m pip --version` fails (**new** — catches broken pip)

Both `.devcontainer/post-create.sh` and `.devcontainer/post-start.sh` now share matching detection logic. The `post-start.sh` flow distinguishes a clean update path (`✅ updated`) from a forced rebuild path (`✅ rebuilt (Python version drift)`) so users see what's happening.

Also switched both scripts from the deprecated `[azure]` extras alias to the canonical `[admin]` (renamed in v5.x via #356; `[azure]` removal scheduled for v6.0).

## Verification

Reproduced and fixed locally:

```text
$ bash .devcontainer/post-start.sh
 ♻️  Updating lightweight tools...
    hook script perms     ✅ fixed
    terraform-mcp-server  ✅ already installed — skipping
    deno                  ✅ deno 2.7.14
    azure-pricing-mcp     ✅ updated      ← was: ModuleNotFoundError: No module named 'pip'
    npm local deps        ✅ ok
    azd auth              ⚠️  not authenticated
    python packages       ✅ updated
    apex-recall           ✅ updated
 ✅ Tool refresh complete (13s)
```

Also verified:
- `bash -n` syntax check passes for both scripts
- `pre-push` checks (branch-scope, branch-naming, diff-based-check) all PASS
- Direct health check: `python -c "from azure_pricing_mcp import server"` returns `OK`

## Files Changed

| File | Change |
|------|--------|
| `.devcontainer/post-create.sh` | Add Python-version-drift detection + `[admin]` extras |
| `.devcontainer/post-start.sh` | Same drift detection (auto-rebuild on version mismatch) + `[admin]` |

## Backward Compatibility

- ✅ Existing healthy venvs are still reused (fast path unchanged)
- ✅ Missing-venv case still rebuilds (existing behavior preserved)
- ✅ `[admin]` extras provides the same dependency set as deprecated `[azure]` alias

## Related

- Follow-up to PR #356 (v5.x extras renamed to `[admin]`) and PR #358 (Copilot review fixes)