### PR TITLE
chore(devcontainer): commit devcontainer-lock.json for reproducible builds

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,49 @@
+{
+  "features": {
+    "ghcr.io/azure/azure-dev/azd:latest": {
+      "version": "0.2.0",
+      "resolved": "ghcr.io/azure/azure-dev/azd@sha256:01bbec064fcb34f7c8730b3e3c2cc210699e213419664524982268b2910c4f73",
+      "integrity": "sha256:01bbec064fcb34f7c8730b3e3c2cc210699e213419664524982268b2910c4f73"
+    },
+    "ghcr.io/devcontainers-community/features/deno": {
+      "version": "1.2.2",
+      "resolved": "ghcr.io/devcontainers-community/features/deno@sha256:159a0943baea16f344b617626ee8612e243ff9e9e13e0c5670b89bcdecd1b775",
+      "integrity": "sha256:159a0943baea16f344b617626ee8612e243ff9e9e13e0c5670b89bcdecd1b775"
+    },
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+      "version": "1.2.9",
+      "resolved": "ghcr.io/devcontainers/features/azure-cli@sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417",
+      "integrity": "sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.3.4",
+      "resolved": "ghcr.io/devcontainers/features/go@sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032",
+      "integrity": "sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/devcontainers/features/powershell:1": {
+      "version": "1.5.1",
+      "resolved": "ghcr.io/devcontainers/features/powershell@sha256:df7baa89598c93bfd15808641d9ec9eb03e0ccdf52e5de4cbbce9ab2d9755d18",
+      "integrity": "sha256:df7baa89598c93bfd15808641d9ec9eb03e0ccdf52e5de4cbbce9ab2d9755d18"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    },
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.4.2",
+      "resolved": "ghcr.io/devcontainers/features/terraform@sha256:250d08e39c99d9e959e091e74527c22c04eeae728b424da99f002423c7902f82",
+      "integrity": "sha256:250d08e39c99d9e959e091e74527c22c04eeae728b424da99f002423c7902f82"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Commits `.devcontainer/devcontainer-lock.json` for reproducible dev container builds across all contributors and CI.

## Why

The lockfile pins exact SHA256 digests for all dev container features (azd, deno, azure-cli, github-cli, go, node, powershell, python, terraform). Without it, every contributor gets whatever feature version is "latest" at their rebuild time.

The recent **Python 3.13 → 3.14 base image upgrade** that broke the azure-pricing MCP venv (fixed in [#359](https://github.com/jonathan-vella/azure-agentic-infraops/pull/359)) is exactly the kind of silent tool drift this lockfile prevents.

## Alignment with Existing Conventions

This matches the project's stated policy in [.gitignore:105](.gitignore#L105):

```text
# DO NOT ignore .terraform.lock.hcl — it must be committed for reproducible
# provider versions
```

Same rationale applies to the devcontainer lockfile.

## Maintenance Expectations

The lockfile auto-regenerates whenever a contributor rebuilds the container with newer feature versions available. Updates surface as PR diffs (similar to `package-lock.json` or `terraform.lock.hcl`), allowing deliberate version-bump review rather than silent drift.

## Files Changed

- `.devcontainer/devcontainer-lock.json` (new, ~50 lines)

## Pinned Versions (snapshot at PR open)

| Feature | Version |
|---------|---------|
| `azure/azure-dev/azd` | 0.2.0 |
| `devcontainers-community/features/deno` | 1.2.2 |
| `devcontainers/features/azure-cli` | 1.2.9 |
| `devcontainers/features/github-cli` | 1.1.0 |
| `devcontainers/features/go` | 1.3.4 |
| `devcontainers/features/node` | 1.7.1 |
| `devcontainers/features/powershell` | 1.5.1 |
| `devcontainers/features/python` | 1.8.0 |
| `devcontainers/features/terraform` | 1.4.2 |

## Related

- [#359](https://github.com/jonathan-vella/azure-agentic-infraops/pull/359) — Python venv rebuild fix (the symptom this lockfile would have prevented)