### PR TITLE
chore(ci): add Dependabot config for devcontainers, actions, npm, pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,116 @@
+# Dependabot configuration for automated dependency updates.
+#
+# Scope: dev container features, GitHub Actions, npm (root + site), and the
+# two in-repo Python packages (azure-pricing MCP, apex-recall). Top-level
+# requirements.txt is intentionally out of scope (managed via uv pin in
+# .devcontainer/post-start.sh).
+#
+# Update cadence is weekly to balance freshness with PR noise. Open PR limit
+# is conservative (3 per ecosystem) to avoid review-queue overload.
+#
+# Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # ─── Dev container features ───────────────────────────────────────────────
+  # Tracks ghcr.io/devcontainers/features/* digests in
+  # .devcontainer/devcontainer.json + regenerates devcontainer-lock.json.
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(devcontainer)"
+    labels:
+      - "dependencies"
+      - "devcontainer"
+
+  # ─── GitHub Actions ────────────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      # Bundle minor/patch bumps of first-party actions (actions/*) to keep
+      # PR volume manageable; security/major bumps still PR individually.
+      actions-minor:
+        patterns:
+          - "actions/*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ─── npm: repo root (validators, lint tooling) ─────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "npm"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ─── npm: docs site (Astro/Starlight) ──────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(site)"
+    labels:
+      - "dependencies"
+      - "site"
+    groups:
+      astro-ecosystem:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+          - "@astrolibs/*"
+          - "starlight*"
+          - "@starlight/*"
+
+  # ─── Python: azure-pricing MCP server ──────────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/tools/mcp-servers/azure-pricing"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(pricing-mcp)"
+    labels:
+      - "dependencies"
+      - "azure-pricing-mcp"
+
+  # ─── Python: apex-recall CLI ───────────────────────────────────────────────
+  - package-ecosystem: "pip"
+    directory: "/tools/apex-recall"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(apex-recall)"
+    labels:
+      - "dependencies"
+      - "apex-recall"


### PR DESCRIPTION
## Summary

Adds Dependabot configuration for **automated weekly dependency updates** across all in-repo ecosystems. Closes the manual-update loop established by [#360](https://github.com/jonathan-vella/azure-agentic-infraops/pull/360) (committing `devcontainer-lock.json`) — Dependabot will now open PRs whenever feature versions or other dependencies have updates available.

## Why

Without Dependabot, the project relies on contributors noticing `git status` changes and manually committing dependency bumps. This is fragile and contributed to the recent Python 3.13 → 3.14 base image drift that broke the azure-pricing MCP venv (fixed in [#359](https://github.com/jonathan-vella/azure-agentic-infraops/pull/359)).

With Dependabot:
- ✅ Weekly automated PRs for each ecosystem
- ✅ Digest changes visible in PR diffs (deliberate version-bump review)
- ✅ Security updates flagged automatically by GitHub
- ✅ Aligns with the project's "commit lockfiles for reproducibility" convention

## Ecosystems Covered

| Ecosystem | Directory | Schedule | Grouping |
|-----------|-----------|----------|----------|
| devcontainers | `/` | Mon weekly | none |
| github-actions | `/` | Mon weekly | `actions/*` minor+patch grouped |
| npm | `/` | Tue weekly | dev deps grouped |
| npm | `/site` | Tue weekly | astro+starlight ecosystem grouped |
| pip | `/tools/mcp-servers/azure-pricing` | Wed weekly | none |
| pip | `/tools/apex-recall` | Wed weekly | none |

**Per-ecosystem caps:** 3 open PRs (prevents review-queue overload)

## Conventional Commit Prefixes

Each ecosystem uses a `commit-message.prefix` matching this repo's commitlint scopes:

- `chore(devcontainer)` — devcontainer features
- `chore(ci)` — GitHub Actions
- `chore(deps)` — root npm dependencies
- `chore(site)` — site/ npm dependencies
- `chore(pricing-mcp)` — azure-pricing MCP server
- `chore(apex-recall)` — apex-recall CLI

## Out of Scope (Deliberate)

| Excluded | Reason |
|----------|--------|
| Top-level `requirements.txt` | Managed via `uv` pins in `.devcontainer/post-start.sh` |
| Go modules | `terraform-mcp-server` is built from upstream clone, not vendored |
| Bicep / Terraform AVM modules | Version-pinned in module sources directly |

## Validation

- ✅ YAML syntax validated (`yaml.safe_load`)
- ✅ Pre-commit + commitlint + pre-push hooks all PASS
- ✅ Conforms to GitHub's [dependabot.yml schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

## What to Expect After Merge

1. Within ~30 minutes, GitHub will register the config and open initial PRs for any out-of-date dependencies (could be 5–15 PRs total on first run).
2. Subsequent updates open weekly on the configured days.
3. Each PR includes the changelog/release notes from the upstream package.
4. Reviewers can merge directly or rebase to combine multiple updates.

## Tuning Levers

If PR volume becomes overwhelming after first run, easy adjustments:

- Lower `open-pull-requests-limit` (e.g. 2 instead of 3)
- Switch interval from `weekly` to `monthly`
- Add `ignore` entries for specific packages that auto-bump too frequently

## Related

- [#359](https://github.com/jonathan-vella/azure-agentic-infraops/pull/359) — Python venv drift fix (the symptom this prevents)
- [#360](https://github.com/jonathan-vella/azure-agentic-infraops/pull/360) — devcontainer-lock.json commit (the file this updates)