### PR TITLE
fix(devcontainer): address Copilot AI review comments from PR #359

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -213,19 +213,27 @@ if [ -d "$MCP_DIR" ]; then
     # site-packages live under lib/python3.X/. Rebuild when version drifts
     # or when ``python -m pip`` cannot import (covers both broken-pip and
     # missing-venv cases).
-    SYS_PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+    #
+    # Probe is fault-tolerant: ``|| echo ""`` keeps ``set -e`` from killing
+    # the whole post-create run if python3 is temporarily unavailable. The
+    # version comparison below gates on both values being non-empty.
+    SYS_PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "")
     VENV_PY_VER=""
     if [ -f "$MCP_DIR/.venv/pyvenv.cfg" ]; then
         VENV_PY_VER=$(grep -E '^version' "$MCP_DIR/.venv/pyvenv.cfg" 2>/dev/null \
             | head -1 | awk '{print $3}' | cut -d'.' -f1-2)
     fi
     REBUILD_VENV=0
+    REBUILD_REASON=""
     if [ ! -f "$MCP_DIR/.venv/bin/python" ]; then
         REBUILD_VENV=1
-    elif [ -n "$VENV_PY_VER" ] && [ "$VENV_PY_VER" != "$SYS_PY_VER" ]; then
+        REBUILD_REASON="missing venv"
+    elif [ -n "$VENV_PY_VER" ] && [ -n "$SYS_PY_VER" ] && [ "$VENV_PY_VER" != "$SYS_PY_VER" ]; then
         REBUILD_VENV=1
+        REBUILD_REASON="Python ${VENV_PY_VER} → ${SYS_PY_VER} drift"
     elif ! "$MCP_DIR/.venv/bin/python" -m pip --version >/dev/null 2>&1; then
         REBUILD_VENV=1
+        REBUILD_REASON="broken pip"
     fi
     if [ "$REBUILD_VENV" -eq 1 ]; then
         rm -rf "$MCP_DIR/.venv" 2>/dev/null || true
@@ -241,7 +249,11 @@ if [ -d "$MCP_DIR" ]; then
     cd - > /dev/null
 
     if "$MCP_DIR/.venv/bin/python" -c "from azure_pricing_mcp import server; print('OK')" 2>/dev/null; then
-        step_done "MCP server installed & health check passed"
+        if [ -n "$REBUILD_REASON" ]; then
+            step_done "MCP server installed & health check passed (rebuilt: ${REBUILD_REASON})"
+        else
+            step_done "MCP server installed & health check passed"
+        fi
     else
         step_warn "MCP server installed but health check failed"
     fi

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -57,22 +57,31 @@ if [ -d "$MCP_DIR" ]; then
             | head -1 | awk '{print $3}' | cut -d'.' -f1-2)
     fi
     REBUILD_VENV=0
+    REBUILD_REASON=""
     if [ ! -f "$MCP_DIR/.venv/bin/python" ]; then
         REBUILD_VENV=1
+        REBUILD_REASON="missing venv"
     elif [ -n "$VENV_PY_VER" ] && [ -n "$SYS_PY_VER" ] && [ "$VENV_PY_VER" != "$SYS_PY_VER" ]; then
         REBUILD_VENV=1
+        REBUILD_REASON="Python ${VENV_PY_VER} → ${SYS_PY_VER} drift"
     elif ! "$MCP_DIR/.venv/bin/python" -m pip --version >/dev/null 2>&1; then
         REBUILD_VENV=1
+        REBUILD_REASON="broken pip"
     fi
     if [ "$REBUILD_VENV" -eq 1 ]; then
         printf "    azure-pricing-mcp     "
+        # Capture stderr to a log so failures are diagnosable without re-running
+        # under set -x. Log path stays in /tmp so it's gitignore-safe.
+        REBUILD_LOG="/tmp/azure-pricing-mcp-rebuild.log"
         rm -rf "$MCP_DIR/.venv" 2>/dev/null || true
-        if python3 -m venv "$MCP_DIR/.venv" 2>/dev/null \
-            && "$MCP_DIR/.venv/bin/python" -m pip install --quiet --upgrade pip >/dev/null 2>&1 \
-            && "$MCP_DIR/.venv/bin/python" -m pip install --quiet -e "$MCP_DIR[admin]" >/dev/null 2>&1; then
-            printf "✅ rebuilt (Python version drift)\n"
+        if { python3 -m venv "$MCP_DIR/.venv" \
+            && "$MCP_DIR/.venv/bin/python" -m pip install --quiet --upgrade pip \
+            && "$MCP_DIR/.venv/bin/python" -m pip install --quiet -e "$MCP_DIR[admin]"; } > "$REBUILD_LOG" 2>&1; then
+            printf "✅ rebuilt (%s)\n" "$REBUILD_REASON"
+            rm -f "$REBUILD_LOG" 2>/dev/null || true
         else
-            printf "⚠️  rebuild failed (continuing)\n"
+            printf "⚠️  rebuild failed (%s) — see %s\n" "$REBUILD_REASON" "$REBUILD_LOG"
+            tail -3 "$REBUILD_LOG" 2>/dev/null | sed 's/^/        /' || true
         fi
     elif [ -f "$MCP_DIR/.venv/bin/python" ]; then
         "$MCP_DIR/.venv/bin/python" -m pip install --quiet --upgrade pip 2>/dev/null || true


### PR DESCRIPTION
## Summary

Addresses the 3 medium-severity Copilot AI review comments on the merged [PR #359](https://github.com/jonathan-vella/azure-agentic-infraops/pull/359).

## Review Comments Addressed

### 1. `post-start.sh` — Rebuild reason classification
The rebuild status always said `"rebuilt (Python version drift)"`, but the same code path also triggered when the venv was missing entirely or when pip was broken for other reasons. Misleading during diagnostics.

**Fix:** Classify the rebuild trigger and emit it in both success and failure messages:
- `"missing venv"`
- `"Python 3.13 → 3.14 drift"` (with actual versions)
- `"broken pip"`

```bash
if [ ! -f "$MCP_DIR/.venv/bin/python" ]; then
    REBUILD_VENV=1
    REBUILD_REASON="missing venv"
elif [ -n "$VENV_PY_VER" ] && [ -n "$SYS_PY_VER" ] && [ "$VENV_PY_VER" != "$SYS_PY_VER" ]; then
    REBUILD_VENV=1
    REBUILD_REASON="Python ${VENV_PY_VER} → ${SYS_PY_VER} drift"
elif ! "$MCP_DIR/.venv/bin/python" -m pip --version >/dev/null 2>&1; then
    REBUILD_VENV=1
    REBUILD_REASON="broken pip"
fi
```

### 2. `post-start.sh` — Capture rebuild stderr to log
Failed rebuilds suppressed all stdout+stderr, leaving zero diagnostic trail. Users had to re-run with manual `set -x` edits to see what broke.

**Fix:** Redirect combined output to `/tmp/azure-pricing-mcp-rebuild.log` on failure. On success, the log is deleted to keep `/tmp` clean. On failure, the path is printed and the last 3 lines are echoed inline (indented) for immediate visibility:

```bash
REBUILD_LOG="/tmp/azure-pricing-mcp-rebuild.log"
if { python3 -m venv "$MCP_DIR/.venv" \
    && "$MCP_DIR/.venv/bin/python" -m pip install --quiet --upgrade pip \
    && "$MCP_DIR/.venv/bin/python" -m pip install --quiet -e "$MCP_DIR[admin]"; } > "$REBUILD_LOG" 2>&1; then
    printf "✅ rebuilt (%s)\n" "$REBUILD_REASON"
    rm -f "$REBUILD_LOG" 2>/dev/null || true
else
    printf "⚠️  rebuild failed (%s) — see %s\n" "$REBUILD_REASON" "$REBUILD_LOG"
    tail -3 "$REBUILD_LOG" 2>/dev/null | sed 's/^/        /' || true
fi
```

### 3. `post-create.sh` — `SYS_PY_VER` fallback under `set -e`
`post-create.sh` runs under `set -e`, so an unguarded `python3 -c '...'` could exit the entire setup before `step_warn` could fire if python3 was temporarily unavailable. `post-start.sh` already used `|| echo ""` but `post-create.sh` did not.

**Fix:** Mirror the post-start.sh pattern — `2>/dev/null || echo ""` plus dual-non-empty gating in the comparison.

```bash
SYS_PY_VER=$(python3 -c '...' 2>/dev/null || echo "")
# ...
elif [ -n "$VENV_PY_VER" ] && [ -n "$SYS_PY_VER" ] && [ "$VENV_PY_VER" != "$SYS_PY_VER" ]; then
```

### Bonus — Inline rebuild reason in post-create.sh too

Since `post-create.sh` now classifies the rebuild reason, the `step_done` message reports it inline when a rebuild occurred:

```bash
if [ -n "$REBUILD_REASON" ]; then
    step_done "MCP server installed & health check passed (rebuilt: ${REBUILD_REASON})"
else
    step_done "MCP server installed & health check passed"
fi
```

Users see the same diagnostic detail during container creation as during refresh.

## Verification

```text
$ bash -n .devcontainer/post-create.sh && bash -n .devcontainer/post-start.sh
syntax OK

$ bash .devcontainer/post-start.sh
    azure-pricing-mcp     ✅ updated
 ✅ Tool refresh complete (22s)
```

## Files Changed

| File | Change |
|------|--------|
| `.devcontainer/post-start.sh` | Rebuild-reason classification + stderr capture to log |
| `.devcontainer/post-create.sh` | `SYS_PY_VER` fallback + matching reason classification |

## Backward Compatibility

- ✅ All existing happy-path messages preserved
- ✅ Failure handling enriched (no behavior regression)
- ✅ Log file path is gitignore-safe (`/tmp/`)

## Related

- Follow-up to [#359](https://github.com/jonathan-vella/azure-agentic-infraops/pull/359) — Python venv drift fix