### PR TITLE
ci(branch-enforcement): allow dependabot/ branches in naming check

### DIFF
--- a/.github/workflows/branch-enforcement.yml
+++ b/.github/workflows/branch-enforcement.yml
@@ -24,9 +24,12 @@ jobs:
         env:
           BRANCH: ${{ github.head_ref }}
         run: |
-          ALLOWED="^(docs|agents|skills|infra|scripts|instructions|fix|chore|feat|ci|refactor|perf|test|build|revert)/"
+          # ``dependabot/...`` is reserved by GitHub for Dependabot-authored
+          # PRs and cannot be renamed; allow the prefix unconditionally so
+          # version-bump PRs aren't blocked by branch naming.
+          ALLOWED="^(docs|agents|skills|infra|scripts|instructions|fix|chore|feat|ci|refactor|perf|test|build|revert|dependabot)/"
           if [[ ! "$BRANCH" =~ $ALLOWED ]]; then
-            echo "::error::Branch '$BRANCH' does not follow naming convention. Use an approved prefix: docs/, agents/, skills/, infra/, scripts/, instructions/, fix/, feat/, chore/, ci/, refactor/, perf/, test/, build/, revert/"
+            echo "::error::Branch '$BRANCH' does not follow naming convention. Use an approved prefix: docs/, agents/, skills/, infra/, scripts/, instructions/, fix/, feat/, chore/, ci/, refactor/, perf/, test/, build/, revert/, dependabot/"
             exit 1
           fi
           echo "✅ Branch '$BRANCH' follows naming convention"
@@ -48,7 +51,7 @@ jobs:
 
           # Cross-cutting prefixes are exempt
           case "$PREFIX" in
-            feat|fix|chore|refactor|revert|perf|test|build|ci)
+            feat|fix|chore|refactor|revert|perf|test|build|ci|dependabot)
               echo "ℹ️  Branch prefix '$PREFIX/' is cross-cutting — no file scope restriction"
               exit 0
               ;;


### PR DESCRIPTION
## Summary

Unblocks all 10 open Dependabot PRs ([#362–#371](https://github.com/jonathan-vella/azure-agentic-infraops/pulls?q=is%3Apr+is%3Aopen+author%3Aapp%2Fdependabot)) by allowing `dependabot/` branches in the CI Branch Naming Convention check.

## Root Cause

All 10 Dependabot PRs failed CI on the **Branch Naming Convention** check:

```text
##[error]Branch 'dependabot/devcontainers/ghcr.io/devcontainers/features/node-2.0.0'
does not follow naming convention. Use an approved prefix:
docs/, agents/, skills/, infra/, scripts/, instructions/, fix/, feat/,
chore/, ci/, refactor/, perf/, test/, build/, revert/
```

The local `tools/scripts/validate-branch-naming.sh` (run via lefthook pre-push hook) already exempts `dependabot/*` branches:

```bash
if [[ "$BRANCH" == "main" || "$BRANCH" == "HEAD" || "$BRANCH" == dependabot/* ]]; then
  exit 0
fi
```

But the CI workflow regex (`.github/workflows/branch-enforcement.yml`) did **not** include `dependabot` as an allowed prefix. Result: every Dependabot PR was blocked.

## Fix

Two edits to `.github/workflows/branch-enforcement.yml`:

1. **`branch-naming` job** — Added `dependabot` to the `ALLOWED` regex
2. **`branch-scope` job** — Added `dependabot` to the cross-cutting prefix list so Dependabot PRs are exempt from per-prefix file-scope restrictions (matches existing `feat|fix|chore|...` handling)

```diff
-          ALLOWED="^(docs|agents|skills|infra|scripts|instructions|fix|chore|feat|ci|refactor|perf|test|build|revert)/"
+          # ``dependabot/...`` is reserved by GitHub for Dependabot-authored
+          # PRs and cannot be renamed; allow the prefix unconditionally so
+          # version-bump PRs aren't blocked by branch naming.
+          ALLOWED="^(docs|agents|skills|infra|scripts|instructions|fix|chore|feat|ci|refactor|perf|test|build|revert|dependabot)/"
```

```diff
           case "$PREFIX" in
-            feat|fix|chore|refactor|revert|perf|test|build|ci)
+            feat|fix|chore|refactor|revert|perf|test|build|ci|dependabot)
               echo "ℹ️  Branch prefix '$PREFIX/' is cross-cutting — no file scope restriction"
               exit 0
               ;;
           esac
```

## Why Dependabot Branches Are Special

GitHub reserves the `dependabot/*` namespace for Dependabot-authored PRs. The branch name format (`dependabot/{ecosystem}/{path}/{name}-{version}`) is **fixed by GitHub** — contributors cannot rename them.

This makes `dependabot` a legitimate cross-cutting prefix (Dependabot PRs span all ecosystems: devcontainers, npm, pip, github-actions).

## Once Merged

All 10 stuck PRs will be unblocked. They can then be triaged on actual content (breaking changes vs safe minor bumps):

| PR | Type | Risk |
|----|------|------|
| #362 | devcontainers/node 1.7 → 2.0 | Major — needs rebuild test |
| #363 | devcontainers/powershell 1.5 → 2.0 | Major |
| #364 | azure/login 2 → 3 | Major action |
| #365 | actions/upload-artifact 5 → 7 | Major (skips 6) |
| #366 | actions/github-script 8 → 9 | Major action |
| #367 | dev-dependencies group (6) | Mixed |
| #368 | @commitlint/config-conventional 20 → 21 | Major |
| #369 | astro-ecosystem group (3) | Minor/patch |
| #370 | eslint-config-prettier 9 → 10 | Major |
| #371 | sharp 0.33 → 0.34 | Minor |

## Verification

- ✅ Local syntax check via existing pre-commit hooks
- ✅ Pre-push checks PASS (branch-naming, branch-scope, diff-based-check)

## Related

- Follow-up to [#361](https://github.com/jonathan-vella/azure-agentic-infraops/pull/361) (Dependabot config that opened these 10 PRs)