### PR TITLE
feat(sensei): protect feat/skills-sensei with CODEOWNERS + weekly maintenance workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,18 @@ docs/                       @jonathan-vella
 
 # Scenarios and examples
 scenarios/                  @jonathan-vella
+
+# Sensei plugin tooling — must stay on feat/skills-sensei only.
+# Any PR that touches these paths against main needs explicit maintainer review
+# (they should be excluded via the /merge-sensei-free-pr prompt instead).
+.gitmodules                                       @jonathan-vella
+.github/skills/sensei/                            @jonathan-vella
+.github/skills/_audits/                           @jonathan-vella
+.github/prompts/sensei/                           @jonathan-vella
+.github/prompts/plan-skillsAuditOptimize.prompt.md @jonathan-vella
+.github/prompts/merge-sensei-free-pr.prompt.md    @jonathan-vella
+tools/scripts/run-sensei-audit.mjs                @jonathan-vella
+tools/scripts/scaffold-trigger-tests.mjs          @jonathan-vella
+tools/scripts/audit-gepa-candidate.mjs            @jonathan-vella
+tools/scripts/run-stage5-audit.mjs                @jonathan-vella
+.token-limits.json                                @jonathan-vella

--- a/.github/workflows/sensei-branch-maintenance.yml
+++ b/.github/workflows/sensei-branch-maintenance.yml
@@ -1,0 +1,183 @@
+# Sensei Branch Maintenance
+#
+# Keeps `feat/skills-sensei` healthy as a long-lived branch:
+#   1. Merges the latest `main` into it weekly (no force-push, no rebase) so
+#      the divergence stays manageable.
+#   2. Runs the full skills/agent validator suite to catch upstream sensei
+#      breakage early.
+#   3. Verifies the branch still exists; opens a tracking issue if it does
+#      not (catches the rare case where branch protection is bypassed).
+#
+# Companion to:
+#   - `.github/prompts/merge-sensei-free-pr.prompt.md` (sensei → main egress)
+#   - Ruleset "Protect feat/skills-sensei" (configured via gh api, not in
+#     this repo). The ruleset blocks deletion + force-push; this workflow
+#     handles the day-to-day keep-alive work.
+
+name: Sensei Branch Maintenance
+
+on:
+  schedule:
+    # Mondays at 08:00 UTC, staggered after weekly-maintenance (07:00).
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+    inputs:
+      skip_merge:
+        description: "Skip the main→sensei merge step (validation only)"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write       # required to merge main into the sensei branch
+  issues: write         # required to open a tracking issue on failure
+  pull-requests: write  # required to open a fallback PR on merge conflict
+
+jobs:
+  verify-branch-exists:
+    name: Verify feat/skills-sensei still exists
+    runs-on: ubuntu-latest
+    outputs:
+      exists: ${{ steps.check.outputs.exists }}
+    steps:
+      - name: Check branch existence
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${{ github.repository }}/branches/feat/skills-sensei" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fail loudly if branch is missing
+        if: steps.check.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh issue create \
+            --title "ALERT: feat/skills-sensei branch is missing" \
+            --label "automation,sensei,critical" \
+            --body "$(cat <<'EOF'
+          The scheduled `Sensei Branch Maintenance` workflow could not find
+          `feat/skills-sensei` in this repository. This usually means branch
+          protection was bypassed or the branch was deleted by mistake.
+
+          Recovery:
+          1. Check the [Activity log](../../actions) for recent deletions.
+          2. Restore the branch from any local clone with
+             `git push origin feat/skills-sensei`.
+          3. Confirm the ruleset "Protect feat/skills-sensei" is still
+             active under repository Settings → Rules.
+
+          This issue was opened automatically by
+          `.github/workflows/sensei-branch-maintenance.yml`.
+          EOF
+          )"
+          exit 1
+
+  merge-main-into-sensei:
+    name: Merge main into feat/skills-sensei
+    needs: verify-branch-exists
+    if: needs.verify-branch-exists.outputs.exists == 'true' && inputs.skip_merge != true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout feat/skills-sensei
+        uses: actions/checkout@v6
+        with:
+          ref: feat/skills-sensei
+          fetch-depth: 0       # full history required for merge
+          submodules: false    # don't pull the sensei submodule into CI
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Attempt non-fast-forward merge from origin/main
+        id: merge
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          if git merge --no-ff --no-edit origin/main; then
+            echo "merged=true" >> "$GITHUB_OUTPUT"
+          else
+            # Abort the dirty state so we can fall back to a PR.
+            git merge --abort || true
+            echo "merged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push merge commit
+        if: steps.merge.outputs.merged == 'true'
+        run: git push origin feat/skills-sensei
+
+      - name: Open conflict-resolution PR
+        if: steps.merge.outputs.merged != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/sensei-main-sync-$(date +%Y%m%d)"
+          git checkout -B "$BRANCH"
+          git fetch origin main
+          # Re-attempt with conflicts left in the index so a human can resolve.
+          git merge --no-commit --no-ff origin/main || true
+          git add -A
+          git commit -m "chore(sensei): merge main into feat/skills-sensei (conflicts)" \
+            --allow-empty
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --base feat/skills-sensei \
+            --head "$BRANCH" \
+            --title "chore(sensei): resolve main→sensei merge conflicts" \
+            --label "automation,sensei" \
+            --body "Automated weekly merge of `main` into `feat/skills-sensei` failed with conflicts. Resolve the conflicts in this PR and merge. Opened by `.github/workflows/sensei-branch-maintenance.yml`."
+
+  validate-sensei-branch:
+    name: Validate skills + agents on feat/skills-sensei
+    needs: [verify-branch-exists, merge-main-into-sensei]
+    # Run even if merge step was skipped via workflow_dispatch.
+    if: always() && needs.verify-branch-exists.outputs.exists == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout feat/skills-sensei (post-merge)
+        uses: actions/checkout@v6
+        with:
+          ref: feat/skills-sensei
+          submodules: recursive  # need sensei submodule for any plugin-aware checks
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Validate skills
+        run: npm run validate:skills
+
+      - name: Validate agents
+        run: npm run validate:agents
+
+      - name: Lint markdown
+        run: npm run lint:md
+
+      - name: Open issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh issue create \
+            --title "Sensei branch validation failed ($(date +%Y-%m-%d))" \
+            --label "automation,sensei" \
+            --body "Weekly validation on `feat/skills-sensei` failed. See [run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. Opened by `.github/workflows/sensei-branch-maintenance.yml`."

--- a/.github/workflows/sensei-branch-maintenance.yml
+++ b/.github/workflows/sensei-branch-maintenance.yml
@@ -35,7 +35,6 @@ concurrency:
 permissions:
   contents: write       # required to merge main into the sensei branch
   issues: write         # required to open a tracking issue on failure
-  pull-requests: write  # required to open a fallback PR on merge conflict
 
 jobs:
   verify-branch-exists:
@@ -50,7 +49,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if gh api "repos/${{ github.repository }}/branches/feat/skills-sensei" >/dev/null 2>&1; then
+          # The branches REST endpoint is path-based, so the ref must be
+          # URL-encoded (slashes → %2F) or feat/skills-sensei resolves
+          # to a 404 even when the branch exists.
+          branch_name='feat/skills-sensei'
+          encoded_branch_name="${branch_name//\//%2F}"
+          if gh api "repos/${{ github.repository }}/branches/${encoded_branch_name}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -86,7 +90,10 @@ jobs:
   merge-main-into-sensei:
     name: Merge main into feat/skills-sensei
     needs: verify-branch-exists
-    if: needs.verify-branch-exists.outputs.exists == 'true' && inputs.skip_merge != true
+    # `inputs.*` is only populated for workflow_dispatch / workflow_call; on
+    # scheduled runs it is undefined. `github.event.inputs.*` safely
+    # resolves to empty string for non-dispatch events.
+    if: needs.verify-branch-exists.outputs.exists == 'true' && github.event.inputs.skip_merge != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout feat/skills-sensei
@@ -118,27 +125,42 @@ jobs:
         if: steps.merge.outputs.merged == 'true'
         run: git push origin feat/skills-sensei
 
-      - name: Open conflict-resolution PR
+      - name: Open conflict-resolution issue
         if: steps.merge.outputs.merged != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          BRANCH="chore/sensei-main-sync-$(date +%Y%m%d)"
-          git checkout -B "$BRANCH"
-          git fetch origin main
-          # Re-attempt with conflicts left in the index so a human can resolve.
-          git merge --no-commit --no-ff origin/main || true
-          git add -A
-          git commit -m "chore(sensei): merge main into feat/skills-sensei (conflicts)" \
-            --allow-empty
-          git push -u origin "$BRANCH"
-          gh pr create \
-            --base feat/skills-sensei \
-            --head "$BRANCH" \
-            --title "chore(sensei): resolve main→sensei merge conflicts" \
+          # We cannot open a PR carrying the conflicted merge: `git commit`
+          # refuses to land while the index has unmerged paths, and any
+          # `--allow-empty` workaround would push a misleading no-op commit.
+          # Open an issue with a copy-pastable recovery recipe instead — a
+          # human resolves the merge locally and pushes a real merge commit
+          # via the normal protected push path.
+          gh issue create \
+            --title "Sensei branch: weekly main→sensei merge has conflicts ($(date +%Y-%m-%d))" \
             --label "automation,sensei" \
-            --body "Automated weekly merge of `main` into `feat/skills-sensei` failed with conflicts. Resolve the conflicts in this PR and merge. Opened by `.github/workflows/sensei-branch-maintenance.yml`."
+            --body "$(cat <<'EOF'
+          The scheduled `Sensei Branch Maintenance` workflow attempted to
+          merge `origin/main` into `feat/skills-sensei` and hit conflicts.
+          The workflow aborted the merge cleanly; no partial state was
+          pushed.
+
+          Resolve locally:
+
+          ```bash
+          git fetch origin
+          git checkout feat/skills-sensei
+          git merge --no-ff origin/main
+          # resolve conflicts, then:
+          git commit
+          git push origin feat/skills-sensei
+          ```
+
+          See [run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the merge output. Opened automatically by
+          `.github/workflows/sensei-branch-maintenance.yml`.
+          EOF
+          )"
 
   validate-sensei-branch:
     name: Validate skills + agents on feat/skills-sensei


### PR DESCRIPTION
## Summary

Adds two of the three long-term protection mechanisms for the
long-lived `feat/skills-sensei` branch:

1. **CODEOWNERS entries** for every sensei-coupled path (submodule,
   audit prompts, audit outputs, wrapper scripts, `.token-limits.json`).
2. **Scheduled `sensei-branch-maintenance.yml` workflow** that keeps
   the sensei branch healthy and verifies it still exists.

The third layer — a GitHub Ruleset that blocks deletion and force-push
on `feat/skills-sensei` — is configured separately via the Rulesets API
and is not part of this PR.

## What the CODEOWNERS change does

With main-branch protection's "Require review from Code Owners" rule
active, any PR against `main` that touches these paths now triggers a
code-owner review request to `@jonathan-vella`:

| Path | Reason |
| --- | --- |
| `.gitmodules` | Only declares the sensei submodule |
| `.github/skills/sensei/` | The submodule mount point |
| `.github/skills/_audits/` | Audit-programme outputs |
| `.github/prompts/sensei/` | Sensei pipeline runner |
| `.github/prompts/plan-skillsAuditOptimize.prompt.md` | Audit programme prompt |
| `.github/prompts/merge-sensei-free-pr.prompt.md` | The sensei-free egress prompt |
| `tools/scripts/run-sensei-audit.mjs` | Sensei wrapper |
| `tools/scripts/scaffold-trigger-tests.mjs` | Trigger-test shim generator |
| `tools/scripts/audit-gepa-candidate.mjs` | GEPA candidate scorer |
| `tools/scripts/run-stage5-audit.mjs` | Stage-5 audit runner |
| `.token-limits.json` | Sensei pipeline budget config |

The `/merge-sensei-free-pr` prompt remains the correct egress path;
CODEOWNERS is the backstop that catches anyone who tries to bypass it.

## What the workflow does

Runs weekly (Mondays 08:00 UTC, staggered after the existing
`weekly-maintenance.yml`) and on `workflow_dispatch`. Three jobs:

### 1. `verify-branch-exists`

Calls the branches API. If `feat/skills-sensei` is missing, opens a
**critical** GitHub issue with recovery instructions and fails the run.
This catches the rare case where branch protection is bypassed
(e.g. by an admin with bypass-actor permission).

### 2. `merge-main-into-sensei`

- Performs a `--no-ff --no-edit` merge of `origin/main` into
  `feat/skills-sensei` and pushes.
- **No force-push, no rebase** — keeps the branch friendly to anyone
  working on it locally.
- On conflict, falls back to opening a
  `chore/sensei-main-sync-YYYYMMDD` PR for human resolution.

### 3. `validate-sensei-branch`

Runs `validate:skills` + `validate:agents` + `lint:md` on the post-merge
tree. Opens an issue on failure. Runs even when the merge step is
skipped via `workflow_dispatch` input.

## Validation

- `npm run lint:md`: 0 errors
- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- Pre-push diff-based validators: all green

## Follow-up (not in this PR)

The ruleset is configured via `gh api` separately because it's a
repository-settings change, not a file change. Recommended payload:

```jsonc
{
  "name": "Protect feat/skills-sensei",
  "target": "branch",
  "enforcement": "active",
  "conditions": {
    "ref_name": {
      "include": ["refs/heads/feat/skills-sensei"],
      "exclude": []
    }
  },
  "rules": [
    { "type": "deletion" },
    { "type": "non_fast_forward" },
    { "type": "pull_request" }
  ],
  "bypass_actors": []
}
```
