### PR TITLE
chore(scripts): exclude upstream-only workflows from sync:workflows

### DIFF
--- a/tools/scripts/sync-workflows.mjs
+++ b/tools/scripts/sync-workflows.mjs
@@ -21,8 +21,22 @@ const UPSTREAM_REPO = "azure-agentic-infraops";
 const UPSTREAM_REF = "main";
 const WORKFLOWS_DIR = ".github/workflows";
 
-// Workflows that are accelerator-specific and should NOT be overwritten
-const SKIP_FILES = new Set(["weekly-upstream-sync.yml"]);
+// Workflows that should NOT be synced from upstream into accelerator-derived
+// repositories. Two categories:
+//   1. Accelerator-only — exists in accelerator, never overwrite from upstream
+//      (e.g. the sync workflow itself).
+//   2. Upstream-only — relevant only to the upstream repo's own infrastructure
+//      (docs site deploy, link-check, e2e validation, sensei-branch maintenance);
+//      consumer projects should not run them.
+const SKIP_FILES = new Set([
+  // Accelerator-only
+  "weekly-upstream-sync.yml",
+  // Upstream-only (docs site, link-check, e2e tests, sensei branch lifecycle)
+  "docs.yml",
+  "link-check.yml",
+  "e2e-validation.yml",
+  "sensei-branch-maintenance.yml",
+]);
 
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run") || args.includes("--dry");
@@ -39,7 +53,7 @@ Options:
   --dry-run   Show what would be fetched without writing files
   --help      Show this help message
 
-Skipped files (accelerator-specific):
+Skipped files (accelerator-only or upstream-only — not relevant to consumer projects):
   ${[...SKIP_FILES].join(", ")}
 `);
   process.exit(0);
@@ -96,7 +110,7 @@ async function main() {
 
   for (const file of ymlFiles) {
     if (SKIP_FILES.has(file.name)) {
-      console.log(`  ⏭️  ${file.name} (skipped — accelerator-specific)`);
+      console.log(`  ⏭️  ${file.name} (skipped — not synced to consumer projects)`);
       skipped++;
       continue;
     }


### PR DESCRIPTION
## Summary

The [Accelerator template](https://github.com/jonathan-vella/azure-agentic-infraops-accelerator)
asks users to run `npm run sync:workflows` to pull GitHub Actions workflows
from this upstream repo into their derived project. Four of the eight
upstream workflows are only relevant to *this repo's* own infrastructure
and should not run in consumer projects — but the script's `SKIP_FILES`
allow-list only excluded one (`weekly-upstream-sync.yml`).

This PR adds the four upstream-only workflows to the skip list.

## Behavior change

Before — `npm run sync:workflows -- --dry-run`:

```text
📋 branch-enforcement.yml         (would fetch)
📋 ci.yml                         (would fetch)
📋 docs.yml                       (would fetch)
📋 e2e-validation.yml             (would fetch)
📋 governance-policy-baseline.yml (would fetch)
📋 link-check.yml                 (would fetch)
📋 sensei-branch-maintenance.yml  (would fetch)
📋 weekly-maintenance.yml         (would fetch)
8 synced, 0 skipped
```

After:

```text
📋 branch-enforcement.yml         (would fetch)
📋 ci.yml                         (would fetch)
⏭️ docs.yml                       (skipped — not synced to consumer projects)
⏭️ e2e-validation.yml             (skipped — not synced to consumer projects)
📋 governance-policy-baseline.yml (would fetch)
⏭️ link-check.yml                 (skipped — not synced to consumer projects)
⏭️ sensei-branch-maintenance.yml  (skipped — not synced to consumer projects)
📋 weekly-maintenance.yml         (would fetch)
4 synced, 4 skipped
```

## Why each one is upstream-only

| Workflow                          | Reason                                                                 |
| --------------------------------- | ---------------------------------------------------------------------- |
| `docs.yml`                        | Deploys the Astro Starlight docs site — content lives only in upstream |
| `link-check.yml`                  | Validates docs-site internal links                                     |
| `e2e-validation.yml`              | This repo's own end-to-end workflow validation                         |
| `sensei-branch-maintenance.yml`   | Lifecycle of the upstream `sensei` branch                              |

## Implementation

[`tools/scripts/sync-workflows.mjs`](tools/scripts/sync-workflows.mjs):

- Restructured `SKIP_FILES` into two clearly-commented categories
  (accelerator-only vs. upstream-only).
- Tweaked the per-file skip log and `--help` text to read
  *"not synced to consumer projects"* (the old "accelerator-specific"
  label was misleading for the new entries).

## Propagation

Confirmed the accelerator's copy of this script is byte-identical
(same blob SHA) to upstream `main`, so the fix flows to derived repos
via the existing weekly-upstream-sync mechanism — no separate edit
needed in the accelerator repo.

## Verification

- `npm run sync:workflows -- --dry-run` against live upstream shows
  the expected 4 / 4 split above.
- Lefthook pre-commit hooks (`js-format`, `js-lint`, `secrets-baseline`)
  all pass on the changed file.
