### PR TITLE
fix(ci): unbreak main — restore canary marker and drop stale workflow node

### DIFF
--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -71,8 +71,7 @@ concurrency:
 | `ci.yml`                        | Required PR check: lint + all Node.js validators | PR + push to main/feature   |
 | `link-check.yml`                | Broken link detection in site docs               | Changes to site/ + weekly   |
 | `docs.yml`                      | Astro Starlight site deployment to Pages         | Push to main (site/)        |
-| `weekly-maintenance.yml`        | AVM version audit + docs freshness checks        | Weekly (Mon 07:00) + manual |
-| `azure-deprecation-tracker.yml` | Azure deprecation monitoring                     | Weekly (Mon 06:00) + manual |
+| `weekly-maintenance.yml`        | AVM version audit + docs freshness + Azure deprecation tracking (folds the retired `azure-deprecation-tracker.yml`) | Weekly (Mon 07:00) + manual |
 
 ## Validation Scripts
 

--- a/.github/skills/iac-common/SKILL.md
+++ b/.github/skills/iac-common/SKILL.md
@@ -59,6 +59,8 @@ Full procedure (`azd up` / `azd provision --preview`, environment preflight chec
 | **azd vs `deploy.ps1` guide** | `references/azd-vs-deploy-guide.md`                                                                                                   |
 | **AVM module index**          | `references/avm-module-index.md` (canonical CSV + JSON list of AVM modules in `.github/data/`)                                        |
 | **AVM version freeze gate**   | `references/avm-version-freeze-gate.md` (Phase 4.4 gate before `plan_status=APPROVED`)                                                |
+| **Codegen shared workflow**   | `references/codegen-shared-workflow.md` (Phase 2 output cadence loaded by `06b`/`06t` CodeGen agents)                                  |
+| **Codegen file-order**        | `references/codegen-file-order.md` (per-tool file emission order loaded by `06b`/`06t` CodeGen agents)                                 |
 | Preflight validation          | `azure-validate/references/infraops-preflight.md`                                                                                     |
 | CLI auth validation procedure | `azure-defaults/references/azure-cli-auth-validation.md`                                                                              |
 | Policy effect decision tree   | `azure-defaults/references/policy-effect-decision-tree.md`                                                                            |

--- a/.github/skills/iac-common/references/codegen-file-order.md
+++ b/.github/skills/iac-common/references/codegen-file-order.md
@@ -1,3 +1,5 @@
+<!-- ref:codegen-file-order-v1 -->
+
 # Codegen File-Order Reference
 
 Per-tool file emission order for Phase 2 of the CodeGen agents

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -147,6 +147,30 @@ pre-commit:
         Checks: frontmatter syntax (description, applyTo only), cross-reference integrity
         📚 Run: npm run validate:instruction-checks
 
+    skill-references:
+      # Catch missing canary markers (`<!-- ref:{slug}-v1 -->`) on skill
+      # references/*.md before they reach main. CI runs the same validator
+      # globally; this hook gives same-PR feedback when a new reference
+      # file is added.
+      glob: ".github/skills/*/references/*.md,.github/skills/*/SKILL.md"
+      run: |
+        STAGED_REFS=$(git diff --cached --name-only --diff-filter=ACM \
+          | grep -E '^\.github/skills/[^/]+/(references/.*\.md|SKILL\.md)$' || true)
+        if [ -n "$STAGED_REFS" ]; then
+          COUNT=$(echo "$STAGED_REFS" | wc -l | tr -d ' ')
+          echo "🔖 Validating $COUNT skill reference/SKILL file(s) (canary markers + size)..."
+          npm run validate:skill-checks
+        else
+          echo "ℹ️  No skill references/SKILL files staged"
+        fi
+      fail_text: |
+        ❌ Skill-references validation failed!
+
+        Every `.github/skills/*/references/*.md` must start with
+        `<!-- ref:{slug}-v1 -->` on the first non-blank line so
+        docs-freshness can detect stale references.
+        🔧 Run: npm run validate:skill-checks
+
     sku-manifest-render:
       glob: "agent-output/*/sku-manifest.json"
       run: |

--- a/site/public/architecture-explorer-graph.json
+++ b/site/public/architecture-explorer-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../tools/schemas/explorer-graph.schema.json",
-  "generatedAt": "2026-05-16T10:47:24.617Z",
+  "generatedAt": "2026-05-17T08:19:08.771Z",
   "categories": [
     {
       "id": "agent",
@@ -48,7 +48,7 @@
       "label": "Validator",
       "color": "#8b5cf6",
       "shape": "hexagon",
-      "count": 49
+      "count": 50
     },
     {
       "id": "workflow",
@@ -56,7 +56,7 @@
       "label": "CI Workflow",
       "color": "#06b6d4",
       "shape": "cut-rectangle",
-      "count": 10
+      "count": 9
     },
     {
       "id": "mcp",
@@ -68,7 +68,7 @@
     }
   ],
   "nodeCount": 150,
-  "edgeCount": 591,
+  "edgeCount": 593,
   "nodes": [
     {
       "id": "agent:01-orchestrator",
@@ -380,7 +380,7 @@
       "id": "agent:10-challenger",
       "category": "agent",
       "label": "10-Challenger",
-      "description": "Thin wrapper for standalone adversarial review. Delegates to challenger-review-subagent. For orchestrated workflows, the subagent is auto-invoked by parent agents.",
+      "description": "Standalone adversarial review wrapper. Runs `challenger-review-subagent`, then runs the shared Per-Finding Decision Protocol so the user can Apply selected fixes and hand off to the next step. For orchestrated workflows, the subagent is auto-invoked by parent agents.",
       "path": ".github/agents/10-challenger.agent.md",
       "links": {
         "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/agents/10-challenger.agent.md"
@@ -1384,6 +1384,19 @@
       }
     },
     {
+      "id": "validator:validate-headings-summary",
+      "category": "validator",
+      "label": "validate:headings-summary",
+      "description": "node tools/scripts/validate-headings-summary.mjs",
+      "path": "package.json",
+      "links": {
+        "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/package.json"
+      },
+      "meta": {
+        "command": "node tools/scripts/validate-headings-summary.mjs"
+      }
+    },
+    {
       "id": "validator:validate-instruction-checks",
       "category": "validator",
       "label": "validate:instruction-checks",
@@ -1929,20 +1942,6 @@
       "parent": "group:validator-orphans"
     },
     {
-      "id": "workflow:azure-deprecation-tracker",
-      "category": "workflow",
-      "label": "azure-deprecation-tracker",
-      "description": "",
-      "path": ".github/workflows/azure-deprecation-tracker.yml",
-      "links": {
-        "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/workflows/azure-deprecation-tracker.yml"
-      },
-      "meta": {
-        "orphan": true
-      },
-      "parent": "group:workflow-orphans"
-    },
-    {
       "id": "workflow:branch-enforcement",
       "category": "workflow",
       "label": "branch-enforcement",
@@ -2137,11 +2136,11 @@
     {
       "id": "group:workflow-orphans",
       "category": "workflow",
-      "label": "CI Workflow (unlinked, 6)",
-      "description": "6 ci workflow nodes with no cross-references in the current graph.",
+      "label": "CI Workflow (unlinked, 5)",
+      "description": "5 ci workflow nodes with no cross-references in the current graph.",
       "isGroup": true,
       "meta": {
-        "groupSize": 6
+        "groupSize": 5
       }
     }
   ],
@@ -4739,6 +4738,12 @@
       "kind": "runs"
     },
     {
+      "id": "workflow:ci--runs->validator:validate-headings-summary",
+      "source": "workflow:ci",
+      "target": "validator:validate-headings-summary",
+      "kind": "runs"
+    },
+    {
       "id": "workflow:ci--runs->validator:lint-governance-refs",
       "source": "workflow:ci",
       "target": "validator:lint-governance-refs",
@@ -5186,6 +5191,12 @@
       "id": "agent:09-diagnose--uses-mcp->mcp:azure-mcp",
       "source": "agent:09-diagnose",
       "target": "mcp:azure-mcp",
+      "kind": "uses-mcp"
+    },
+    {
+      "id": "agent:10-challenger--uses-mcp->mcp:github",
+      "source": "agent:10-challenger",
+      "target": "mcp:github",
       "kind": "uses-mcp"
     },
     {


### PR DESCRIPTION
## Summary

Two CI validators have been failing on `main` since the merges of PR #390 (which added a new reference file) and the August 2025 retirement of `azure-deprecation-tracker.yml`. Both failures pre-exist on `main` and were surfaced (but not caused by) PR #400.

This PR unbreaks `main` and adds a guard rail to prevent recurrence.

## Failures fixed

### 1. `validate:skill-checks`

```text
❌ iac-common/references/codegen-file-order.md missing canary marker
   (expected `<!-- ref:codegen-file-order-v1 -->` on line 1)
```

`.github/skills/iac-common/references/codegen-file-order.md` was added in PR #390 without the canary marker the validator requires on the first non-blank line.

- Prepended `<!-- ref:codegen-file-order-v1 -->` to the file.
- Wired the file into `.github/skills/iac-common/SKILL.md` Reference Index (sibling `codegen-shared-workflow.md` reference also added for symmetry — both are loaded on-demand by `06b`/`06t` CodeGen agents).

### 2. `validate:explorer-graph`

```text
❌ Node "workflow:azure-deprecation-tracker" references missing file:
   .github/workflows/azure-deprecation-tracker.yml
```

The standalone `azure-deprecation-tracker.yml` workflow was retired in August 2025 and folded into `weekly-maintenance.yml`, but `site/public/architecture-explorer-graph.json` still carried an orphan node pointing at the deleted file.

- Regenerated via `npm run build:explorer-graph` — the generator scans `.github/workflows/` on disk, so the orphan dropped out cleanly.
- Updated the "Existing Workflows" table in `.github/instructions/github-actions.instructions.md` to reflect the folded-in deprecation tracking.

## Prevent recurrence

Added a `skill-references` command to [`lefthook.yml`](./lefthook.yml) that runs `npm run validate:skill-checks` when any `.github/skills/*/references/*.md` or `SKILL.md` is staged. This catches missing canary markers in the same PR that introduces the new reference file (the failure mode that landed PR #390 broken).

## Validation

All previously failing validators now pass:

| Validator | Result |
| --- | --- |
| `npm run validate:skill-checks` | ✅ 33 files, 0 errors |
| `npm run validate:explorer-graph` (`EXPLORER_GRAPH_STRICT=1`) | ✅ valid |
| `npm run validate:instruction-checks` | ✅ 65 checks, 0 errors |
| `npm run lint:orphaned-content` | ✅ pass (2 unrelated warnings) |
| `npm run lint:json` | ✅ 98 files |
| `npm run lint:safe-shell` | ✅ 123 files, 0 violations |

Pre-push hooks: 7/7 passed.

## Files changed

- `.github/skills/iac-common/references/codegen-file-order.md` — canary marker
- `.github/skills/iac-common/SKILL.md` — Reference Index wiring (codegen-file-order + codegen-shared-workflow)
- `.github/instructions/github-actions.instructions.md` — drop stale `azure-deprecation-tracker.yml` row, note fold-in
- `site/public/architecture-explorer-graph.json` — regenerated (stale workflow node removed)
- `lefthook.yml` — new `skill-references` pre-commit hook
