### PR TITLE
chore(deps): upgrade @eslint/js to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@commitlint/cli": "^21.0.1",
         "@commitlint/config-conventional": "^21.0.1",
-        "@eslint/js": "^9.17.0",
+        "@eslint/js": "^10.0.1",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "eslint": "^10.4.0",
@@ -621,13 +621,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
-      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
-    "@eslint/js": "^9.17.0",
+    "@eslint/js": "^10.0.1",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "eslint": "^10.4.0",

--- a/site/public/architecture-explorer-graph.json
+++ b/site/public/architecture-explorer-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../tools/schemas/explorer-graph.schema.json",
-  "generatedAt": "2026-05-21T17:55:59.832Z",
+  "generatedAt": "2026-05-28T20:06:54.095Z",
   "categories": [
     {
       "id": "agent",
@@ -24,7 +24,7 @@
       "label": "Skill",
       "color": "#10b981",
       "shape": "ellipse",
-      "count": 33
+      "count": 34
     },
     {
       "id": "instruction",
@@ -67,8 +67,8 @@
       "count": 6
     }
   ],
-  "nodeCount": 157,
-  "edgeCount": 672,
+  "nodeCount": 158,
+  "edgeCount": 681,
   "nodes": [
     {
       "id": "agent:01-orchestrator",
@@ -80,7 +80,7 @@
         "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/agents/01-orchestrator.agent.md"
       },
       "meta": {
-        "model": "GPT-5.3-Codex",
+        "model": "GPT-5.4 mini",
         "invocable": true,
         "subagents": [
           "02-Requirements",
@@ -129,7 +129,7 @@
         "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/agents/02-requirements.agent.md"
       },
       "meta": {
-        "model": "GPT-5.5",
+        "model": "Claude Sonnet 4.6",
         "invocable": true,
         "subagents": [
           "challenger-review-subagent"
@@ -156,7 +156,7 @@
         "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/agents/03-architect.agent.md"
       },
       "meta": {
-        "model": "Claude Opus 4.7",
+        "model": "Claude Opus 4.8",
         "invocable": true,
         "subagents": [
           "cost-estimate-subagent",
@@ -229,7 +229,8 @@
         "skills": [
           "azure-defaults",
           "azure-governance-discovery",
-          "azure-artifacts"
+          "azure-artifacts",
+          "iac-common"
         ]
       }
     },
@@ -243,7 +244,7 @@
         "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/agents/05-iac-planner.agent.md"
       },
       "meta": {
-        "model": "Claude Sonnet 4.6",
+        "model": "Claude Opus 4.8",
         "invocable": true,
         "subagents": [
           "challenger-review-subagent"
@@ -353,7 +354,8 @@
         ],
         "skills": [
           "azure-defaults",
-          "azure-artifacts"
+          "azure-artifacts",
+          "iac-common"
         ]
       }
     },
@@ -384,7 +386,8 @@
         ],
         "skills": [
           "azure-defaults",
-          "azure-artifacts"
+          "azure-artifacts",
+          "iac-common"
         ]
       }
     },
@@ -398,7 +401,7 @@
         "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/agents/08-as-built.agent.md"
       },
       "meta": {
-        "model": "GPT-5.5",
+        "model": "Claude Sonnet 4.6",
         "invocable": true,
         "subagents": [
           "cost-estimate-subagent"
@@ -934,6 +937,17 @@
       "path": ".github/skills/python-diagrams/SKILL.md",
       "links": {
         "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/skills/python-diagrams/SKILL.md"
+      },
+      "meta": {}
+    },
+    {
+      "id": "skill:sensei",
+      "category": "skill",
+      "label": "sensei",
+      "description": "**WORKFLOW SKILL** — Iteratively improve skill frontmatter compliance using the Ralph loop pattern. WHEN: \\\"run sensei\\\", \\\"sensei help\\\", \\\"improve skill\\\", \\\"fix frontmatter\\\", \\\"skill compliance\\\", \\\"frontmatter audit\\\", \\\"score skill\\\", \\\"check skill tokens\\\". INVOKES: token counting tools, test runners, git commands. FOR SINGLE OPERATIONS: use token CLI directly for counts/checks.",
+      "path": ".github/skills/sensei/SKILL.md",
+      "links": {
+        "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/skills/sensei/SKILL.md"
       },
       "meta": {}
     },
@@ -3004,6 +3018,12 @@
       "kind": "uses-skill"
     },
     {
+      "id": "agent:04g-governance--uses-skill->skill:iac-common",
+      "source": "agent:04g-governance",
+      "target": "skill:iac-common",
+      "kind": "uses-skill"
+    },
+    {
       "id": "agent:05-iac-planner--uses-skill->skill:azure-defaults",
       "source": "agent:05-iac-planner",
       "target": "skill:azure-defaults",
@@ -3100,6 +3120,12 @@
       "kind": "uses-skill"
     },
     {
+      "id": "agent:07b-bicep-deploy--uses-skill->skill:iac-common",
+      "source": "agent:07b-bicep-deploy",
+      "target": "skill:iac-common",
+      "kind": "uses-skill"
+    },
+    {
       "id": "agent:07t-terraform-deploy--uses-skill->skill:azure-defaults",
       "source": "agent:07t-terraform-deploy",
       "target": "skill:azure-defaults",
@@ -3109,6 +3135,12 @@
       "id": "agent:07t-terraform-deploy--uses-skill->skill:azure-artifacts",
       "source": "agent:07t-terraform-deploy",
       "target": "skill:azure-artifacts",
+      "kind": "uses-skill"
+    },
+    {
+      "id": "agent:07t-terraform-deploy--uses-skill->skill:iac-common",
+      "source": "agent:07t-terraform-deploy",
+      "target": "skill:iac-common",
       "kind": "uses-skill"
     },
     {
@@ -3652,6 +3684,12 @@
       "kind": "applies-to"
     },
     {
+      "id": "instruction:agent-skills--applies-to->skill:sensei",
+      "source": "instruction:agent-skills",
+      "target": "skill:sensei",
+      "kind": "applies-to"
+    },
+    {
       "id": "instruction:agent-skills--applies-to->skill:terraform-patterns",
       "source": "instruction:agent-skills",
       "target": "skill:terraform-patterns",
@@ -3979,6 +4017,12 @@
       "id": "instruction:context-optimization--applies-to->skill:python-diagrams",
       "source": "instruction:context-optimization",
       "target": "skill:python-diagrams",
+      "kind": "applies-to"
+    },
+    {
+      "id": "instruction:context-optimization--applies-to->skill:sensei",
+      "source": "instruction:context-optimization",
+      "target": "skill:sensei",
       "kind": "applies-to"
     },
     {
@@ -4315,6 +4359,12 @@
       "id": "instruction:docs-trigger--applies-to->skill:python-diagrams",
       "source": "instruction:docs-trigger",
       "target": "skill:python-diagrams",
+      "kind": "applies-to"
+    },
+    {
+      "id": "instruction:docs-trigger--applies-to->skill:sensei",
+      "source": "instruction:docs-trigger",
+      "target": "skill:sensei",
       "kind": "applies-to"
     },
     {
@@ -4828,6 +4878,12 @@
       "kind": "applies-to"
     },
     {
+      "id": "instruction:markdown--applies-to->skill:sensei",
+      "source": "instruction:markdown",
+      "target": "skill:sensei",
+      "kind": "applies-to"
+    },
+    {
       "id": "instruction:markdown--applies-to->skill:terraform-patterns",
       "source": "instruction:markdown",
       "target": "skill:terraform-patterns",
@@ -5155,6 +5211,12 @@
       "id": "instruction:no-interactive-shell--applies-to->skill:python-diagrams",
       "source": "instruction:no-interactive-shell",
       "target": "skill:python-diagrams",
+      "kind": "applies-to"
+    },
+    {
+      "id": "instruction:no-interactive-shell--applies-to->skill:sensei",
+      "source": "instruction:no-interactive-shell",
+      "target": "skill:sensei",
       "kind": "applies-to"
     },
     {
@@ -6307,6 +6369,12 @@
       "id": "skill:python-diagrams--refs->skill:mermaid",
       "source": "skill:python-diagrams",
       "target": "skill:mermaid",
+      "kind": "refs"
+    },
+    {
+      "id": "skill:sensei--refs->skill:azure-deploy",
+      "source": "skill:sensei",
+      "target": "skill:azure-deploy",
       "kind": "refs"
     },
     {

--- a/site/public/architecture-explorer-graph.json
+++ b/site/public/architecture-explorer-graph.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../tools/schemas/explorer-graph.schema.json",
-  "generatedAt": "2026-05-28T20:06:54.095Z",
+  "generatedAt": "2026-05-28T20:24:28.166Z",
   "categories": [
     {
       "id": "agent",
@@ -24,7 +24,7 @@
       "label": "Skill",
       "color": "#10b981",
       "shape": "ellipse",
-      "count": 34
+      "count": 33
     },
     {
       "id": "instruction",
@@ -67,8 +67,8 @@
       "count": 6
     }
   ],
-  "nodeCount": 158,
-  "edgeCount": 681,
+  "nodeCount": 157,
+  "edgeCount": 675,
   "nodes": [
     {
       "id": "agent:01-orchestrator",
@@ -937,17 +937,6 @@
       "path": ".github/skills/python-diagrams/SKILL.md",
       "links": {
         "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/skills/python-diagrams/SKILL.md"
-      },
-      "meta": {}
-    },
-    {
-      "id": "skill:sensei",
-      "category": "skill",
-      "label": "sensei",
-      "description": "**WORKFLOW SKILL** — Iteratively improve skill frontmatter compliance using the Ralph loop pattern. WHEN: \\\"run sensei\\\", \\\"sensei help\\\", \\\"improve skill\\\", \\\"fix frontmatter\\\", \\\"skill compliance\\\", \\\"frontmatter audit\\\", \\\"score skill\\\", \\\"check skill tokens\\\". INVOKES: token counting tools, test runners, git commands. FOR SINGLE OPERATIONS: use token CLI directly for counts/checks.",
-      "path": ".github/skills/sensei/SKILL.md",
-      "links": {
-        "source": "https://github.com/jonathan-vella/azure-agentic-infraops/blob/main/.github/skills/sensei/SKILL.md"
       },
       "meta": {}
     },
@@ -3684,12 +3673,6 @@
       "kind": "applies-to"
     },
     {
-      "id": "instruction:agent-skills--applies-to->skill:sensei",
-      "source": "instruction:agent-skills",
-      "target": "skill:sensei",
-      "kind": "applies-to"
-    },
-    {
       "id": "instruction:agent-skills--applies-to->skill:terraform-patterns",
       "source": "instruction:agent-skills",
       "target": "skill:terraform-patterns",
@@ -4017,12 +4000,6 @@
       "id": "instruction:context-optimization--applies-to->skill:python-diagrams",
       "source": "instruction:context-optimization",
       "target": "skill:python-diagrams",
-      "kind": "applies-to"
-    },
-    {
-      "id": "instruction:context-optimization--applies-to->skill:sensei",
-      "source": "instruction:context-optimization",
-      "target": "skill:sensei",
       "kind": "applies-to"
     },
     {
@@ -4359,12 +4336,6 @@
       "id": "instruction:docs-trigger--applies-to->skill:python-diagrams",
       "source": "instruction:docs-trigger",
       "target": "skill:python-diagrams",
-      "kind": "applies-to"
-    },
-    {
-      "id": "instruction:docs-trigger--applies-to->skill:sensei",
-      "source": "instruction:docs-trigger",
-      "target": "skill:sensei",
       "kind": "applies-to"
     },
     {
@@ -4878,12 +4849,6 @@
       "kind": "applies-to"
     },
     {
-      "id": "instruction:markdown--applies-to->skill:sensei",
-      "source": "instruction:markdown",
-      "target": "skill:sensei",
-      "kind": "applies-to"
-    },
-    {
       "id": "instruction:markdown--applies-to->skill:terraform-patterns",
       "source": "instruction:markdown",
       "target": "skill:terraform-patterns",
@@ -5211,12 +5176,6 @@
       "id": "instruction:no-interactive-shell--applies-to->skill:python-diagrams",
       "source": "instruction:no-interactive-shell",
       "target": "skill:python-diagrams",
-      "kind": "applies-to"
-    },
-    {
-      "id": "instruction:no-interactive-shell--applies-to->skill:sensei",
-      "source": "instruction:no-interactive-shell",
-      "target": "skill:sensei",
       "kind": "applies-to"
     },
     {
@@ -6369,12 +6328,6 @@
       "id": "skill:python-diagrams--refs->skill:mermaid",
       "source": "skill:python-diagrams",
       "target": "skill:mermaid",
-      "kind": "refs"
-    },
-    {
-      "id": "skill:sensei--refs->skill:azure-deploy",
-      "source": "skill:sensei",
-      "target": "skill:azure-deploy",
       "kind": "refs"
     },
     {

--- a/tools/scripts/generate-explorer-graph.mjs
+++ b/tools/scripts/generate-explorer-graph.mjs
@@ -186,7 +186,7 @@ function collectSubagents() {
 
 function collectSkills() {
   const skillsDir = join(REPO_ROOT, ".github/skills");
-  let dirs = [];
+  let dirs;
   try {
     dirs = readdirSync(skillsDir).filter((d) => statSync(join(skillsDir, d)).isDirectory());
   } catch {

--- a/tools/scripts/validate-sku-iac-coverage.mjs
+++ b/tools/scripts/validate-sku-iac-coverage.mjs
@@ -359,7 +359,7 @@ function findProjects() {
 }
 
 function diffModeProjects() {
-  let changed = "";
+  let changed;
   try {
     changed = execSync("git diff --name-only HEAD 2>/dev/null", { cwd: ROOT }).toString();
     if (!changed.trim()) {

--- a/tools/scripts/validate-sku-manifest.mjs
+++ b/tools/scripts/validate-sku-manifest.mjs
@@ -424,7 +424,7 @@ function main() {
   }
 
   const validate = loadValidator();
-  let vnetWhitelist = null;
+  let vnetWhitelist;
   try {
     vnetWhitelist = loadVnetAttachedWhitelist();
   } catch (err) {


### PR DESCRIPTION
- chore(deps): upgrade all dependencies to latest versions

## Summary

- Bump `@eslint/js` 9.17.0 → 10.0.1 (align with eslint v10)
- Refresh root `package-lock.json`
- Site rebuild regenerated `architecture-explorer-graph.json`

## Audit

- Root npm: 0 vulnerabilities
- Site npm: 0 vulnerabilities
- Python (`pip-audit`): 1 false-positive (`PYSEC-2024-270` misattributed to `mingrammer/diagrams`; actual CVE is against unrelated `Airflow-Diagrams`)

## Out of scope

- `.github/skills/sensei/` (embedded git repo) — upgrade tracked separately in that repo.